### PR TITLE
Improve MAC address caching for WiFi selection

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -18,6 +18,10 @@
 #include "fontIds.h"
 #include "util/TimeUtils.h"
 
+#if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
+#include "esp_system.h"
+#endif
+
 void WifiSelectionActivity::onEnter() {
   Activity::onEnter();
 
@@ -41,13 +45,27 @@ void WifiSelectionActivity::onEnter() {
   forgetPromptSelection = 0;
   autoConnecting = false;
 
-  // Cache MAC address for display
-  uint8_t mac[6];
-  WiFi.macAddress(mac);
-  char macStr[64];
-  snprintf(macStr, sizeof(macStr), "%s %02x-%02x-%02x-%02x-%02x-%02x", tr(STR_MAC_ADDRESS), mac[0], mac[1], mac[2],
-           mac[3], mac[4], mac[5]);
-  cachedMacAddress = std::string(macStr);
+  // Cache MAC address for display.
+  // On ESP32 read the base MAC directly to avoid placeholder/uninitialized values
+  // returned when the WiFi driver hasn't been fully initialized yet.
+  #if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
+    uint8_t baseMac[6];
+    esp_read_mac(baseMac, ESP_MAC_WIFI_STA);
+    char macStr[64];
+    snprintf(macStr, sizeof(macStr), "%s %02x-%02x-%02x-%02x-%02x-%02x", tr(STR_MAC_ADDRESS),
+             baseMac[0], baseMac[1], baseMac[2], baseMac[3], baseMac[4], baseMac[5]);
+    cachedMacAddress = std::string(macStr);
+  #else
+    // Fallback: ensure WiFi is in station mode before reading macAddress()
+    WiFi.mode(WIFI_STA);
+    delay(10);
+    uint8_t mac[6];
+    WiFi.macAddress(mac);
+    char macStr[64];
+    snprintf(macStr, sizeof(macStr), "%s %02x-%02x-%02x-%02x-%02x-%02x", tr(STR_MAC_ADDRESS),
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    cachedMacAddress = std::string(macStr);
+  #endif
 
   // Trigger first update to show scanning message
   requestUpdate();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  
  Ensure the device shows the correct ESP32 MAC address the first time the WiFi screen is opened (Home > Sync Day > WiFi Networks), avoiding a placeholder/uninitialized MAC like `01-00-00-00-01-00` that appears on first view, as this seems to cause failures at first wifi sync attempt.

* **What changes are included?**  
  - Read the ESP32 base MAC directly using esp_read_mac(..., ESP_MAC_WIFI_STA) and display that value in the WiFi subheader.
  - Add compile guards so this direct read is used only on ESP32 targets. For other platforms, explicitly set WIFI_STA mode and call WiFi.macAddress() after a short delay as a fallback.
  - Updated file:
    - src/activities/network/WifiSelectionActivity.cpp

## Additional Context

* Why: The symptom (placeholder MAC displayed on first open, correct MAC after a re-scan) is caused by reading WiFi.macAddress() before the Wi‑Fi driver is fully initialized into station mode. Reading the hardware base MAC via esp_read_mac returns the correct MAC immediately and prevents the placeholder value from being shown.
* Testing steps:
  1. Build and flash to an ESP32 device.
  2. Boot device and open Home > Sync Day > WiFi Networks.
  3. Verify the subheader "MAC Address" shows the real ESP32 MAC on the first view (no re-scan required).
  4. Also test connecting to a network to ensure hostname generation and connection behavior are unchanged.
* Performance implications: none of significance — a single small read at activity entry. The fallback adds a short delay (10ms) to ensure WiFi driver initialization on non-ESP32 platforms.
* Potential risks / areas to focus on for review:
  - Confirm esp_read_mac and esp_system.h are available in the build environment for the supported ESP32 toolchain (esp-idf/arduino-esp32). The change is guarded by preprocessor checks so it will not be used on non-ESP32 targets.
  - Verify there are no unexpected side effects from calling WiFi.mode(WIFI_STA) early in onEnter() on non-ESP32 targets (the code uses a small delay and only in the fallback path).
  - Confirm hostname generation (attemptConnection uses WiFi.macAddress()) still produces expected router-visible hostnames after this change.
* Notes:
  - The change is intentionally minimal and targeted; it only changes how the MAC is read and does not modify UI layout or connection logic.
  - If reviewers prefer, the fallback can be removed and the code can rely exclusively on the esp_read_mac approach for ESP32-only builds.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_