### PR TITLE
fix: SleepScreenCache uses compile-time buffer size, breaks X3 sleep covers

### DIFF
--- a/src/util/SleepScreenCache.cpp
+++ b/src/util/SleepScreenCache.cpp
@@ -54,7 +54,8 @@ bool SleepScreenCache::load(GfxRenderer& renderer, const std::string& sourcePath
     return false;
   }
 
-  if (file.fileSize() != HalDisplay::BUFFER_SIZE) {
+  const uint32_t bufferSize = display.getBufferSize();
+  if (file.fileSize() != bufferSize) {
     LOG_ERR("SLC", "Invalid cache size for %s", path.c_str());
     file.close();
     Storage.remove(path.c_str());
@@ -62,10 +63,10 @@ bool SleepScreenCache::load(GfxRenderer& renderer, const std::string& sourcePath
   }
 
   uint8_t* frameBuffer = renderer.getFrameBuffer();
-  const int bytesRead = file.read(frameBuffer, HalDisplay::BUFFER_SIZE);
+  const int bytesRead = file.read(frameBuffer, bufferSize);
   file.close();
 
-  if (bytesRead != static_cast<int>(HalDisplay::BUFFER_SIZE)) {
+  if (bytesRead != static_cast<int>(bufferSize)) {
     LOG_ERR("SLC", "Incomplete cache read for %s", path.c_str());
     return false;
   }
@@ -89,11 +90,12 @@ void SleepScreenCache::save(const GfxRenderer& renderer, const std::string& sour
     return;
   }
 
+  const uint32_t bufferSize = display.getBufferSize();
   const uint8_t* frameBuffer = renderer.getFrameBuffer();
-  const size_t bytesWritten = file.write(frameBuffer, HalDisplay::BUFFER_SIZE);
+  const size_t bytesWritten = file.write(frameBuffer, bufferSize);
   file.close();
 
-  if (bytesWritten != HalDisplay::BUFFER_SIZE) {
+  if (bytesWritten != bufferSize) {
     LOG_ERR("SLC", "Incomplete cache write for %s", path.c_str());
     Storage.remove(path.c_str());
     return;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix sleep screen cover images rendering with left-edge cropping on X3 when using Contrast or Invert filter.
* **What changes are included?** Replace compile-time `HalDisplay::BUFFER_SIZE` (48000 bytes, hardcoded for 800x480) with runtime `display.getBufferSize()` in `SleepScreenCache::load()` and `SleepScreenCache::save()`. The X3 framebuffer is 52272 bytes (792x528), so the old code truncated the saved framebuffer.

## Additional Context
                                                            
- Only affects X3. X4 buffer size is unchanged at 48000 bytes, so no regression expected.                                                                                                                       
- First render is always correct (direct BMP decode bypasses cache). The bug only appears on subsequent sleeps when the truncated cache is loaded.
- "None" filter is unaffected because `canUseSleepCache()` skips caching for greyscale BMPs with no filter.                                                                                                       

| Before | After | 
|-|-|                                                                                                                                                                                             
| ![before](https://github.com/user-attachments/assets/0a447d98-9353-4689-b588-0b4d0521833c) | ![after](https://github.com/user-attachments/assets/123eb676-6c5d-4ecb-8373-3b2ea6de7475) |

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_