### PR TITLE
fix: reuse Sync Day Wi-Fi mode for KOReader sync and scan-first auto-connect

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -67,26 +67,8 @@ void WifiSelectionActivity::onEnter() {
   // Trigger first update to show scanning message
   requestUpdate();
 
-  // Attempt to auto-connect to the last network
-  if (allowAutoConnect) {
-    const std::string lastSsid = WIFI_STORE.getLastConnectedSsid();
-    if (!lastSsid.empty()) {
-      const auto* cred = WIFI_STORE.findCredential(lastSsid);
-      if (cred) {
-        LOG_DBG("WIFI", "Attempting to auto-connect to %s", lastSsid.c_str());
-        selectedSSID = cred->ssid;
-        enteredPassword = cred->password;
-        selectedRequiresPassword = !cred->password.empty();
-        usedSavedPassword = true;
-        autoConnecting = true;
-        attemptConnection();
-        requestUpdate();
-        return;
-      }
-    }
-  }
-
-  // Fallback to scanning
+  // Auto mode always scans first so we only attempt remembered networks that
+  // are actually in range.
   startWifiScan();
 }
 
@@ -180,15 +162,32 @@ void WifiSelectionActivity::processWifiScanResults() {
   WiFi.scanDelete();
 
   // Auto-connect to the best saved-password network if one is in range and the
-  // parent flow explicitly allows automatic selection.
-  // Networks are already sorted: saved-password first, then by RSSI descending,
-  // so networks[0] is always the best candidate.
-  if (allowAutoConnect && !networks.empty() && networks[0].hasSavedPassword) {
-    LOG_DBG("WIFI", "Found saved network in range: %s (RSSI: %d) - auto-connecting", networks[0].ssid.c_str(),
-            networks[0].rssi);
-    selectedNetworkIndex = 0;
-    selectNetwork(0);
-    return;
+  // parent flow explicitly allows automatic selection. Prefer the last
+  // connected SSID when it is present in scan results; otherwise fall back to
+  // the strongest saved network because the list is already sorted with saved
+  // networks first and RSSI descending inside each group.
+  if (allowAutoConnect && !networks.empty()) {
+    const std::string lastSsid = WIFI_STORE.getLastConnectedSsid();
+    if (!lastSsid.empty()) {
+      const auto remembered = std::find_if(networks.begin(), networks.end(), [&lastSsid](const WifiNetworkInfo& network) {
+        return network.ssid == lastSsid && network.hasSavedPassword;
+      });
+      if (remembered != networks.end()) {
+        selectedNetworkIndex = static_cast<size_t>(std::distance(networks.begin(), remembered));
+        LOG_DBG("WIFI", "Found last connected network in range: %s (RSSI: %d) - auto-connecting", remembered->ssid.c_str(),
+                remembered->rssi);
+        connectUsingSavedCredential(*remembered, true);
+        return;
+      }
+    }
+
+    if (networks[0].hasSavedPassword) {
+      selectedNetworkIndex = 0;
+      LOG_DBG("WIFI", "Found saved network in range: %s (RSSI: %d) - auto-connecting", networks[0].ssid.c_str(),
+              networks[0].rssi);
+      connectUsingSavedCredential(networks[0], true);
+      return;
+    }
   }
 
   state = WifiSelectionState::NETWORK_LIST;
@@ -208,14 +207,7 @@ void WifiSelectionActivity::selectNetwork(const int index) {
   enteredPassword.clear();
   autoConnecting = false;
 
-  // Check if we have saved credentials for this network
-  const auto* savedCred = WIFI_STORE.findCredential(selectedSSID);
-  if (savedCred && !savedCred->password.empty()) {
-    // Use saved password - connect directly
-    enteredPassword = savedCred->password;
-    usedSavedPassword = true;
-    LOG_DBG("WiFi", "Using saved password for %s, length: %zu", selectedSSID.c_str(), enteredPassword.size());
-    attemptConnection();
+  if (connectUsingSavedCredential(network, false)) {
     return;
   }
 
@@ -239,6 +231,22 @@ void WifiSelectionActivity::selectNetwork(const int index) {
     // Connect directly for open networks
     attemptConnection();
   }
+}
+
+bool WifiSelectionActivity::connectUsingSavedCredential(const WifiNetworkInfo& network, const bool isAutoConnectAttempt) {
+  const auto* savedCred = WIFI_STORE.findCredential(network.ssid);
+  if (!savedCred || savedCred->password.empty()) {
+    return false;
+  }
+
+  selectedSSID = network.ssid;
+  selectedRequiresPassword = network.isEncrypted;
+  enteredPassword = savedCred->password;
+  usedSavedPassword = true;
+  autoConnecting = isAutoConnectAttempt;
+  LOG_DBG("WiFi", "Using saved password for %s, length: %zu", selectedSSID.c_str(), enteredPassword.size());
+  attemptConnection();
+  return true;
 }
 
 void WifiSelectionActivity::attemptConnection() {

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -91,6 +91,7 @@ class WifiSelectionActivity final : public Activity {
   void startWifiScan();
   void processWifiScanResults();
   void selectNetwork(int index);
+  bool connectUsingSavedCredential(const WifiNetworkInfo& network, bool isAutoConnectAttempt);
   void attemptConnection();
   void checkConnectionStatus();
   std::string getSignalStrengthIndicator(int32_t rssi) const;

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -388,8 +388,9 @@ void KOReaderSyncActivity::onEnter() {
     return;
   }
 
+  const bool chooseWifiManually = SETTINGS.syncDayWifiChoice == CrossPointSettings::SYNC_DAY_WIFI_MANUAL;
   LOG_DBG("KOSync", "Launching WifiSelectionActivity...");
-  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
+  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput, !chooseWifiManually),
                          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
 }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  
  Make KOReader sync respect the existing Sync Day `Choose WiFi` preference, and make `Auto` behave more reliably by scanning before attempting a saved network.

* **What changes are included?**  
  - read `syncDayWifiChoice` when launching standalone KOReader sync
  - use `WifiSelectionActivity` auto-connect mode when Sync Day is set to `Auto`
  - keep manual Wi-Fi selection when Sync Day is set to `Manual`
  - change `WifiSelectionActivity` auto-connect behavior to scan first
  - when `Auto` is used, prefer `lastConnectedSsid` only if it is actually in range
  - if the last connected SSID is not in range, fall back to another saved network in range
  - leave the KOReader authentication/setup flow unchanged

## Additional Context

* Tested manually on device in VS Code build/upload workflow.
* Verified the following behavior:
  - when Sync Day `Choose WiFi` is set to `Auto`, KOReader sync reuses saved Wi-Fi networks
  - when Sync Day `Choose WiFi` is set to `Manual`, KOReader sync still opens the Wi-Fi chooser
  - in `Auto`, Wi-Fi now scans first instead of immediately trying the remembered SSID without checking whether it is available
  - if the remembered SSID is in range, `Auto` still prefers it
  - if the remembered SSID is out of range but another saved network is available, `Auto` falls back to that saved network
* Main risk area is the Wi-Fi selection flow, since this now affects how `Auto` chooses saved networks after scanning.
* A useful reviewer focus area is whether reusing the Sync Day Wi-Fi preference for KOReader sync is the right scope, and whether the scan-first `Auto` selection policy matches expected behavior for saved Wi-Fi networks.

---

### AI Usage

Did you use AI tools to help write this code? _**Yes**_