### PR TITLE
fix: Updated-lyra-carousel-theme-bugs

### DIFF
--- a/scripts/check_lyra_carousel_port.py
+++ b/scripts/check_lyra_carousel_port.py
@@ -45,7 +45,16 @@ def main() -> None:
     require("src/components/themes/lyra/LyraCarouselTheme.h", "drawCarouselBorder")
     require("src/components/themes/lyra/LyraCarouselTheme.cpp", "void LyraCarouselTheme::drawCarouselBorder")
     require("src/components/themes/lyra/LyraCarouselTheme.cpp", "const std::string legacyThumbPath")
+    require("src/components/themes/lyra/LyraCarouselTheme.cpp", "const std::string centerThumbPath")
     require("src/components/themes/lyra/LyraCarouselTheme.cpp", "LyraCarouselMetrics::values.homeCoverHeight")
+    require("src/components/themes/lyra/LyraCarouselTheme.cpp", "kCenterCoverW, kCenterCoverH")
+    carousel_theme = read("src/components/themes/lyra/LyraCarouselTheme.cpp")
+    draw_cover_fn = carousel_theme[
+        carousel_theme.index("auto drawCover = "):
+        carousel_theme.index("if (!coverRendered)")
+    ]
+    if "LyraMetrics::values.homeCoverHeight" in draw_cover_fn:
+        raise AssertionError("Lyra Carousel must not render the low-resolution Lyra thumb_226.bmp fallback")
     require("src/activities/home/HomeActivity.h", "kCarouselFrameCount")
     require("src/activities/home/HomeActivity.h", "preRenderCarouselFrames")
     require("src/activities/home/HomeActivity.cpp", "void HomeActivity::preRenderCarouselFrames")
@@ -64,11 +73,40 @@ def main() -> None:
         raise AssertionError("HomeActivity::render should not prerender carousel frames before drawing the first screen")
 
     load_covers = home_activity[home_activity.index("void HomeActivity::loadRecentCovers"):home_activity.index("void HomeActivity::onEnter()")]
-    if "LyraCarouselTheme::kCenterCoverW" in load_covers or "LyraCarouselTheme::kSideCoverW" in load_covers:
-        raise AssertionError("HomeActivity::loadRecentCovers should not generate exact carousel thumbnails during startup")
+    if "LyraCarouselTheme::kSideCoverW" in load_covers:
+        raise AssertionError("HomeActivity::loadRecentCovers should not generate side carousel thumbnails during startup")
     require("src/activities/home/HomeActivity.cpp", "if (isLyraCarouselTheme() && progress != lastCarouselBookIndex)")
     require("src/activities/home/HomeActivity.cpp", "void HomeActivity::scheduleCarouselCoverLoadIfNeeded")
     require("src/activities/home/HomeActivity.cpp", "epub.load(isLyraCarouselTheme(), true)")
+    require("src/activities/home/HomeActivity.cpp", "lyra-carousel-frame-v6-carousel-thumb-only")
+    require("src/activities/home/HomeActivity.cpp", "getCarouselCenterThumbPath")
+    require("src/activities/home/HomeActivity.cpp", "hasCarouselUsableThumb")
+    require("src/activities/home/HomeActivity.cpp", "LyraCarouselTheme::kCenterCoverW")
+    require("src/activities/home/HomeActivity.cpp", "LyraCarouselTheme::kCenterCoverH")
+    require("src/activities/home/HomeActivity.cpp", "hashCarouselThumbState")
+    require("src/activities/home/HomeActivity.cpp", "if (!success && !isLyraCarouselTheme())")
+    require("src/activities/home/HomeActivity.h", "carouselCoverLoadAttemptPath")
+    require("src/activities/home/HomeActivity.cpp", "carouselCoverLoadAttemptPath = book.path")
+    require("src/activities/home/HomeActivity.cpp", "book.path != carouselCoverLoadAttemptPath")
+    require("src/activities/home/HomeActivity.cpp", "carouselCoverLoadAttemptPath.clear()")
+    legacy_thumb_fn = home_activity[
+        home_activity.index("bool hasCarouselUsableThumb"):
+        home_activity.index("void HomeActivity::loadHomeCarouselBooks")
+    ]
+    if "LyraMetrics::values.homeCoverHeight" in legacy_thumb_fn:
+        raise AssertionError(
+            "Carousel cover loading must not treat thumb_226.bmp as a usable Carousel cover"
+        )
+    load_covers_after_checks = home_activity[
+        home_activity.index("void HomeActivity::loadRecentCovers"):
+        home_activity.index("void HomeActivity::scheduleCarouselCoverLoadIfNeeded")
+    ]
+    if "epub.generateThumbBmp(coverHeight)" not in load_covers_after_checks:
+        raise AssertionError("Non-carousel cover loading should still use the active theme height")
+    require("src/activities/home/HomeActivity.cpp",
+            "epub.generateThumbBmp(LyraCarouselTheme::kCenterCoverW")
+    require("src/activities/home/HomeActivity.cpp",
+            "xtc.generateThumbBmp(LyraCarouselTheme::kCenterCoverW")
 
     # preRenderCarouselFrames must render only the center frame (slot 0), not all
     # three, so the user sees their selected book immediately on first paint and

--- a/scripts/check_reader_status_bar.py
+++ b/scripts/check_reader_status_bar.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def main() -> None:
+    epub_reader = read("src/activities/reader/EpubReaderActivity.cpp")
+    gray_block = epub_reader[
+        epub_reader.index("if (enableTextAA || enableImageGrayscaleOnly)"):
+        epub_reader.index("renderer.displayGrayBuffer();")
+    ]
+    if gray_block.count("renderStatusBar();") < 2:
+        raise AssertionError(
+            "EPUB grayscale rendering must include the status bar in both gray buffers"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -154,7 +154,7 @@ std::string getHomeShortcutSubtitle(const HomeShortcutEntry& entry) {
 
 UIIcon getHomeShortcutIcon(const HomeShortcutEntry& entry) {
   if (entry.isAppsHub) {
-    return UIIcon::Book;
+    return UIIcon::Apps;
   }
   return entry.definition ? entry.definition->icon : UIIcon::Folder;
 }
@@ -193,10 +193,41 @@ uint32_t fnv1aU32(uint32_t hash, const uint32_t value) {
   return fnv1aByte(hash, static_cast<uint8_t>((value >> 24) & 0xFF));
 }
 
+std::string getCarouselCenterThumbPath(const RecentBook& book) {
+  return UITheme::getCoverThumbPath(book.coverBmpPath, LyraCarouselTheme::kCenterCoverW,
+                                    LyraCarouselTheme::kCenterCoverH);
+}
+
+std::string getCarouselLegacyThumbPath(const RecentBook& book) {
+  return UITheme::getCoverThumbPath(book.coverBmpPath, LyraCarouselMetrics::values.homeCoverHeight);
+}
+
+bool hasCarouselUsableThumb(const RecentBook& book) {
+  if (book.coverBmpPath.empty()) {
+    return true;
+  }
+  const std::string centerCoverPath = getCarouselCenterThumbPath(book);
+  if (Storage.exists(centerCoverPath.c_str())) {
+    return true;
+  }
+  const std::string legacyCoverPath = getCarouselLegacyThumbPath(book);
+  return Storage.exists(legacyCoverPath.c_str());
+}
+
+uint32_t hashCarouselThumbState(uint32_t hash, const RecentBook& book) {
+  if (book.coverBmpPath.empty()) {
+    return fnv1aByte(hash, 0);
+  }
+  const std::string centerCoverPath = getCarouselCenterThumbPath(book);
+  const std::string legacyCoverPath = getCarouselLegacyThumbPath(book);
+  hash = fnv1aByte(hash, Storage.exists(centerCoverPath.c_str()) ? 1 : 0);
+  return fnv1aByte(hash, Storage.exists(legacyCoverPath.c_str()) ? 1 : 0);
+}
+
 uint32_t getCarouselFrameHash(const std::vector<RecentBook>& books, const int centerIdx, const int screenWidth,
                               const int screenHeight, const size_t bufferSize, const bool darkMode) {
   uint32_t hash = FNV1A_OFFSET;
-  hash = fnv1aString(hash, "lyra-carousel-frame-v4-dark-clean");
+  hash = fnv1aString(hash, "lyra-carousel-frame-v6-carousel-thumb-only");
   hash = fnv1aU32(hash, static_cast<uint32_t>(screenWidth));
   hash = fnv1aU32(hash, static_cast<uint32_t>(screenHeight));
   hash = fnv1aU32(hash, static_cast<uint32_t>(bufferSize));
@@ -211,6 +242,7 @@ uint32_t getCarouselFrameHash(const std::vector<RecentBook>& books, const int ce
     hash = fnv1aString(hash, book.title);
     hash = fnv1aString(hash, book.author);
     hash = fnv1aString(hash, book.coverBmpPath);
+    hash = hashCarouselThumbState(hash, book);
   }
 
   return hash;
@@ -225,14 +257,6 @@ std::string getCarouselFrameCachePath(const std::vector<RecentBook>& books, cons
   return filename;
 }
 
-bool hasLegacyHomeThumb(const RecentBook& book) {
-  if (book.coverBmpPath.empty()) {
-    return true;
-  }
-  const std::string coverPath =
-      UITheme::getCoverThumbPath(book.coverBmpPath, LyraCarouselMetrics::values.homeCoverHeight);
-  return Storage.exists(coverPath.c_str());
-}
 }  // namespace
 
 int HomeActivity::getMenuItemCount() const {
@@ -281,7 +305,7 @@ bool HomeActivity::needsRecentCoverLoad(const int coverHeight) const {
     }
 
     const bool missingThumb = isLyraCarouselTheme()
-                                  ? !hasLegacyHomeThumb(book)
+                                  ? !hasCarouselUsableThumb(book)
                                   : !Storage.exists(UITheme::getCoverThumbPath(book.coverBmpPath, coverHeight).c_str());
     if (missingThumb && (FsHelpers::hasEpubExtension(book.path) || FsHelpers::hasXtcExtension(book.path))) {
       return true;
@@ -304,9 +328,12 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
     }
     if (!book.coverBmpPath.empty()) {
       const bool missingThumb =
-          isLyraCarouselTheme() ? !hasLegacyHomeThumb(book)
+          isLyraCarouselTheme() ? !hasCarouselUsableThumb(book)
                                 : !Storage.exists(UITheme::getCoverThumbPath(book.coverBmpPath, coverHeight).c_str());
       if (missingThumb) {
+        if (isLyraCarouselTheme()) {
+          carouselCoverLoadAttemptPath = book.path;
+        }
         if (FsHelpers::hasEpubExtension(book.path)) {
           Epub epub(book.path, "/.crosspoint");
           epub.load(isLyraCarouselTheme(), true);
@@ -317,8 +344,11 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
           }
           GUI.fillPopupProgress(renderer, popupRect,
                                 10 + progress * (90 / std::max(1, static_cast<int>(recentBooks.size()))));
-          const bool success = epub.generateThumbBmp(coverHeight);
-          if (!success) {
+          const bool success = isLyraCarouselTheme()
+                                   ? epub.generateThumbBmp(LyraCarouselTheme::kCenterCoverW,
+                                                          LyraCarouselTheme::kCenterCoverH)
+                                   : epub.generateThumbBmp(coverHeight);
+          if (!success && !isLyraCarouselTheme()) {
             RECENT_BOOKS.updateBook(book.path, book.title, book.author, "");
             book.coverBmpPath = "";
           }
@@ -333,8 +363,11 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
             }
             GUI.fillPopupProgress(renderer, popupRect,
                                   10 + progress * (90 / std::max(1, static_cast<int>(recentBooks.size()))));
-            const bool success = xtc.generateThumbBmp(coverHeight);
-            if (!success) {
+            const bool success = isLyraCarouselTheme()
+                                     ? xtc.generateThumbBmp(LyraCarouselTheme::kCenterCoverW,
+                                                            LyraCarouselTheme::kCenterCoverH)
+                                     : xtc.generateThumbBmp(coverHeight);
+            if (!success && !isLyraCarouselTheme()) {
               RECENT_BOOKS.updateBook(book.path, book.title, book.author, "");
               book.coverBmpPath = "";
             }
@@ -365,7 +398,7 @@ void HomeActivity::scheduleCarouselCoverLoadIfNeeded() {
     return;
   }
   const RecentBook& book = recentBooks[lastCarouselBookIndex];
-  if (!book.coverBmpPath.empty() && !hasLegacyHomeThumb(book) &&
+  if (!book.coverBmpPath.empty() && book.path != carouselCoverLoadAttemptPath && !hasCarouselUsableThumb(book) &&
       (FsHelpers::hasEpubExtension(book.path) || FsHelpers::hasXtcExtension(book.path))) {
     recentsLoaded = false;
     requestUpdate();
@@ -383,6 +416,7 @@ void HomeActivity::onEnter() {
   recentsLoaded = false;
   lastCarouselBookIndex = 0;
   carouselFramesReady = false;
+  carouselCoverLoadAttemptPath.clear();
 
   const auto& metrics = UITheme::getInstance().getMetrics();
   loadHomeCarouselBooks(metrics.homeRecentBooksCount);

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 #include <vector>
 
 #include "../Activity.h"
@@ -21,6 +22,7 @@ class HomeActivity final : public Activity {
   bool coverBufferStored = false;  // Track if cover buffer is stored
   uint8_t* coverBuffer = nullptr;  // HomeActivity's own buffer for cover image
   int lastCarouselBookIndex = 0;
+  std::string carouselCoverLoadAttemptPath;
   uint8_t* carouselFrames[3] = {nullptr, nullptr, nullptr};
   int carouselFrameBookIdx[3] = {-1, -1, -1};
   bool carouselFramesReady = false;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1073,6 +1073,7 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     } else {
       page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop, SETTINGS.bionicReading);
     }
+    renderStatusBar();
     renderer.copyGrayscaleLsbBuffers();
     const auto tGrayLsb = millis();
 
@@ -1084,6 +1085,7 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     } else {
       page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop, SETTINGS.bionicReading);
     }
+    renderStatusBar();
     renderer.copyGrayscaleMsbBuffers();
     const auto tGrayMsb = millis();
 

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -70,7 +70,7 @@ struct ThemeMetrics {
   int keyboardWidthPercent;
 };
 
-enum UIIcon { Folder, Text, Image, Book, File, Recent, Settings, Transfer, Library, Trophy, Wifi, Hotspot, Heart };
+enum UIIcon { Folder, Text, Image, Book, File, Recent, Settings, Apps, Transfer, Library, Trophy, Wifi, Hotspot, Heart };
 enum class KeyboardKeyType { Normal, Shift, Mode, Space, Del, Ok, Disabled };
 
 // Default theme implementation (Classic Theme)

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -22,6 +22,7 @@
 #include "components/icons/image24.h"
 #include "components/icons/library.h"
 #include "components/icons/recent.h"
+#include "components/icons/settings.h"
 #include "components/icons/settings2.h"
 #include "components/icons/text24.h"
 #include "components/icons/trophy.h"
@@ -77,6 +78,8 @@ const uint8_t* iconForName(UIIcon icon, int size) {
         return RecentIcon;
       case UIIcon::Settings:
         return Settings2Icon;
+      case UIIcon::Apps:
+        return SettingsIcon;
       case UIIcon::Transfer:
         return TransferIcon;
       case UIIcon::Library:
@@ -153,10 +156,16 @@ void LyraCarouselTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect,
     bool hasCover = false;
     if (!book.coverBmpPath.empty()) {
       std::string thumbPath = UITheme::getCoverThumbPath(book.coverBmpPath, maxW, maxH);
+      const std::string centerThumbPath =
+          UITheme::getCoverThumbPath(book.coverBmpPath, kCenterCoverW, kCenterCoverH);
       const std::string legacyThumbPath =
           UITheme::getCoverThumbPath(book.coverBmpPath, LyraCarouselMetrics::values.homeCoverHeight);
-      if (!Storage.exists(thumbPath.c_str()) && Storage.exists(legacyThumbPath.c_str())) {
-        thumbPath = legacyThumbPath;
+      if (!Storage.exists(thumbPath.c_str())) {
+        if (Storage.exists(centerThumbPath.c_str())) {
+          thumbPath = centerThumbPath;
+        } else if (Storage.exists(legacyThumbPath.c_str())) {
+          thumbPath = legacyThumbPath;
+        }
       }
       FsFile file;
       if (Storage.openFileForRead("HOME", thumbPath, file)) {

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -27,6 +27,7 @@
 #include "components/icons/image24.h"
 #include "components/icons/library.h"
 #include "components/icons/recent.h"
+#include "components/icons/settings.h"
 #include "components/icons/settings2.h"
 #include "components/icons/text.h"
 #include "components/icons/text24.h"
@@ -108,6 +109,8 @@ const uint8_t* iconForName(UIIcon icon, int size) {
         return RecentIcon;
       case UIIcon::Settings:
         return Settings2Icon;
+      case UIIcon::Apps:
+        return SettingsIcon;
       case UIIcon::Transfer:
         return TransferIcon;
       case UIIcon::Library:


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  
  Add a new `Lyra Carousel` home-screen theme that shows recent books (or favorites) in a scrollable cover carousel with a two-axis navigation model and a pinned shortcut bar below.

* **What changes are included?**  
  - add `LyraCarouselTheme` class with cover carousel, dot indicator, and icon-row shortcut bar
  - pre-render only the center frame at startup; fill adjacent frames lazily after the first paint to avoid extra SD reads on boot
  - store pre-rendered frames with `inCarouselRow=false` (thin outline); overlay selection border via `drawCarouselBorder()` at display time only, avoiding permanently baked thick borders on e-ink
  - two-axis navigation: Left/Right cycles within the active row (books or shortcuts); Up/Down switches between rows; button hints reflect the active axis
  - carousel shortcut bar pins Settings and Apps to the last two slots regardless of home shortcut configuration, so the user is never locked out; first three slots show other home shortcuts in user-configured order
  - add `generateThumbBmp(int width, int height)` to `Epub` and `Xtc` for exact-size thumbnail generation
  - add `UITheme::getCoverThumbPath(path, w, h)` overload for exact-size thumbnail paths
  - generate and use exact Lyra Carousel thumbnails (`thumb_340x540.bmp`) instead of falling back to the tiny `thumb_226.bmp`
  - keep legacy `thumb_600.bmp` as a fallback when an exact carousel thumbnail is absent
  - include carousel thumbnail availability in the frame cache hash so stale placeholder frames are invalidated after cover generation
  - attempt carousel thumbnail generation after returning from a book when the exact thumbnail is missing
  - `epub.load(isLyraCarouselTheme(), true)` builds the full EPUB cache when missing to ensure covers are generated on first load
  - render the EPUB reader status bar into both grayscale refresh passes so the configured progress bar remains visible while reading
  - add a distinct `UIIcon::Apps` value and map Apps to the existing gear icon, while Settings keeps the existing settings shortcut icon
  - add `scripts/check_lyra_carousel_port.py` to verify carousel port invariants that are easy to break during future rebases
  - add `scripts/check_reader_status_bar.py` to guard the reader status bar rendering path
  - register `LYRA_CAROUSEL` in settings, strings, web server, and settings UI

## Additional Context

* Tested manually on device (Xteink X4, ESP32-C3, 800×480 e-ink).
* Verified the following behavior:
  - boot is fast; only the center carousel frame is rendered before the first paint
  - adjacent carousel frames load lazily after the first paint
  - cover carousel shows the selected book centered with previous/next books partially visible on the sides
  - carousel covers render from exact-size thumbnails when available
  - missing carousel thumbnails are generated after opening/closing a book
  - covers fall back gracefully to placeholder when no usable thumbnail exists
  - side carousel books show cover images instead of generic placeholders once thumbnail cache state is valid
  - Left/Right navigates books or shortcuts depending on which row is focused
  - Up/Down switches between the book row and the shortcut row
  - Settings and Apps are always reachable from the shortcut bar
  - Apps uses a gear-style icon so it is easier to distinguish from Stats/Books
  - the EPUB reader status bar/progress bar is visible while reading
  - long-press on a recent book still opens the delete confirmation (recents source only)
* Main risk area is the carousel frame cache: three framebuffers are heap-allocated and freed on exit.
* A useful reviewer focus area is whether the lazy sliding-window cache strategy (`updateSlidingWindowCache`) interacts correctly with rapid Left/Right input before the background render completes.
* Another useful reviewer focus area is whether thumbnail cache invalidation stays correct when SD-card cover files are created or deleted outside the device.

---

### AI Usage

Did you use AI tools to help write this code? _**Yes**_
