### PR TITLE
fix: use runtime geometry for inverted icons / Xteink 3 showing black icons in carousel theme

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -743,8 +743,8 @@ void GfxRenderer::drawIconInverted(const uint8_t bitmap[], const int x, const in
   const int imgH = width;
   const int srcStride = (imgW + 7) / 8;
 
-  if (physX + imgW <= 0 || physX >= HalDisplay::DISPLAY_WIDTH) return;
-  if (physY + imgH <= 0 || physY >= HalDisplay::DISPLAY_HEIGHT) return;
+  if (physX + imgW <= 0 || physX >= panelWidth) return;
+  if (physY + imgH <= 0 || physY >= panelHeight) return;
 
   const int baseByte = (physX >= 0) ? (physX >> 3) : -(((-physX) + 7) >> 3);
   const int bitShift = ((physX % 8) + 8) % 8;
@@ -754,15 +754,15 @@ void GfxRenderer::drawIconInverted(const uint8_t bitmap[], const int x, const in
 
   for (int row = 0; row < imgH; ++row) {
     const int destY = physY + row;
-    if (destY < 0 || destY >= HalDisplay::DISPLAY_HEIGHT) continue;
-    const int rowBase = destY * HalDisplay::DISPLAY_WIDTH_BYTES;
+    if (destY < 0 || destY >= panelHeight) continue;
+    const int rowBase = destY * panelWidthBytes;
     const int srcOffset = row * srcStride;
 
     if (bitShift == 0) {
       for (int col = 0; col < srcStride; ++col) {
         const int dst = baseByte + col;
         if (dst < 0) continue;
-        if (dst >= HalDisplay::DISPLAY_WIDTH_BYTES) break;
+        if (dst >= panelWidthBytes) break;
         uint8_t inv = ~bitmap[srcOffset + col];
         if (col == lastCol && trail > 0) inv &= trailMask;
         frameBuffer[rowBase + dst] |= inv;
@@ -775,10 +775,10 @@ void GfxRenderer::drawIconInverted(const uint8_t bitmap[], const int x, const in
         if (col == lastCol && trail > 0) inv &= trailMask;
         const int dstHi = baseByte + col;
         const int dstLo = dstHi + 1;
-        if (dstHi >= 0 && dstHi < HalDisplay::DISPLAY_WIDTH_BYTES) {
+        if (dstHi >= 0 && dstHi < panelWidthBytes) {
           frameBuffer[rowBase + dstHi] |= static_cast<uint8_t>(inv >> rsh);
         }
-        if (dstLo >= 0 && dstLo < HalDisplay::DISPLAY_WIDTH_BYTES) {
+        if (dstLo >= 0 && dstLo < panelWidthBytes) {
           frameBuffer[rowBase + dstLo] |= static_cast<uint8_t>(inv << lsh);
         }
       }


### PR DESCRIPTION
## Summary

Fixes inverted icon rendering on Xteink X3 by using runtime display geometry in `GfxRenderer::drawIconInverted()`, which cause icons to show a black square.

<img width="632" height="733" alt="image" src="https://github.com/user-attachments/assets/e8958e2a-6f93-4038-a2e7-b33cba056d56" />

## Root Cause

Got report from reddit user _AardvarkInfamous2852_ that the Lyra Carousel theme is showing black squares in icons.

Lyra Carousel selected menu icons use `drawIconInverted()`, which wrote directly into the framebuffer using X4 compile-time dimensions. X3 uses a different runtime panel width and framebuffer stride, so inverted icon rows were written with incorrect offsets.

## Impact

Selected icons in the Lyra Carousel theme should render correctly on X3 instead of appearing as black squares.

## Validation

Built locally and got assistance from reddit user _AardvarkInfamous2852_ to test this directly in X3, this has fixed the icons.
<img width="425" height="603" alt="image" src="https://github.com/user-attachments/assets/197252aa-4246-43ed-b534-d16e4a714e1c" />

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_