### PR TITLE
fix: Show actual current progress badge

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -329,7 +329,7 @@ uint8_t getCarouselBookProgressPercent(const RecentBook& recentBook) {
   if (stats == nullptr) {
     return 0;
   }
-  return stats->completed ? 100 : std::min<uint8_t>(stats->lastProgressPercent, 100);
+  return std::min<uint8_t>(stats->lastProgressPercent, 100);
 }
 
 uint32_t getCarouselFrameHash(const std::vector<RecentBook>& books, const int centerIdx, const int screenWidth,

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -124,7 +124,7 @@ uint8_t getBookProgressPercent(const RecentBook& recentBook) {
   if (stats == nullptr) {
     return 0;
   }
-  return stats->completed ? 100 : std::min<uint8_t>(stats->lastProgressPercent, 100);
+  return std::min<uint8_t>(stats->lastProgressPercent, 100);
 }
 
 void drawProgressBadge(GfxRenderer& renderer, const RecentBook& book, const int coverX, const int coverY,


### PR DESCRIPTION
## Summary
**TL;DR:**
- Lyra Carousel progress badges now display the current saved reading position instead of forcing `100%` whenever a book has a sticky completed flag.
- The carousel frame cache key now follows that same current progress value, so cached Home frames refresh when progress changes after returning to earlier pages.

**Goal:** Keep the Home carousel badge aligned with the reader's current position without changing completed-book semantics elsewhere on the ESP32-C3's constrained firmware path.

A user report showed a book displaying `100%` in the Lyra Carousel while `reading_stats.json` had `lastProgressPercent: 36` and `completed: true`. The root cause was that the carousel helpers treated the sticky completion flag as display progress.
- Accidental navigation to the end can set `completed=true`.
- Returning to an earlier position can lower `lastProgressPercent`.
- The carousel still rendered `100%` because it preferred `completed` over the current saved position.

---

## Changes
### Lyra Carousel Progress
**1. Use current progress for carousel cache keys** (`src/activities/home/HomeActivity.cpp`)
The carousel frame hash now uses `lastProgressPercent` directly instead of converting completed books to `100`. This lets cached Home frames invalidate when current progress changes after a user returns to an earlier page.

**2. Use current progress for the visible badge** (`src/components/themes/lyra/LyraCarouselTheme.cpp`)
The central cover badge now displays `lastProgressPercent` for the selected recent book. The completed flag remains untouched for stats, file badges, achievements, and completed-book workflows.

---

## File summary
| File | What changed |
|---|---|
| `src/activities/home/HomeActivity.cpp` | Removed the completed-to-100 override from the carousel frame progress helper. |
| `src/components/themes/lyra/LyraCarouselTheme.cpp` | Removed the completed-to-100 override from the Lyra badge progress helper. |

---

## Testing performed
| Scenario | Result |
|---|---|
| Branch compare against `master` | ✅ Two intended carousel files only |
| Book stats case (`completed=true`, `lastProgressPercent=36`) | ✅ Confirmed expected behavior with user-provided SD-card `reading_stats.json`; user confirmed the repair worked |
| `git diff --check` on modified files | ✅ No whitespace errors |
| `pio run -e default` | [ ] Blocked by unrelated `open-x4-sdk` / `InputManager::getPowerButtonHeldTime` mismatch in `lib/hal/HalGPIO.cpp` |

*Note: Testing was local against the user's SD-card data and repository diff. PlatformIO firmware build was attempted, but failed before this patch due to the existing SDK/HAL mismatch noted above; no on-device flash test was performed in this chat.*

---

## Pending / Known limitations
### Sticky Completion Semantics Remain
This PR intentionally does not clear `completed` when a reader moves backward after accidentally reaching the end. That broader behavior affects stats, achievements, completed-book movement, and file browser completion markers, so this patch limits the behavioral change to the Lyra Carousel's visible progress and frame cache key.

---

### AI Usage
Did you use AI tools to help write this code? **PARTIALLY**