### PR TITLE
fix: preserve reader progress display and spine zero resume

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -329,7 +329,7 @@ uint8_t getCarouselBookProgressPercent(const RecentBook& recentBook) {
   if (stats == nullptr) {
     return 0;
   }
-  return stats->completed ? 100 : std::min<uint8_t>(stats->lastProgressPercent, 100);
+  return std::min<uint8_t>(stats->lastProgressPercent, 100);
 }
 
 uint32_t getCarouselFrameHash(const std::vector<RecentBook>& books, const int centerIdx, const int screenWidth,

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -215,6 +215,7 @@ void EpubReaderActivity::onEnter() {
   bookmarkStore.load(epub->getCachePath(), stableBookId);
 
   FsFile f;
+  bool loadedProgress = false;
   bool loadedFromLegacy = false;
   const std::string stableProgressPath = getStableProgressPath(stableBookId);
   const std::string legacyProgressPath = getLegacyProgressPath(*epub);
@@ -234,6 +235,7 @@ void EpubReaderActivity::onEnter() {
         nextPageNumber = 0;
       }
       cachedSpineIndex = currentSpineIndex;
+      loadedProgress = true;
       LOG_DBG("ERS", "Loaded cache: %d, %d", currentSpineIndex, nextPageNumber);
     }
     if (dataSize == 6) {
@@ -244,9 +246,8 @@ void EpubReaderActivity::onEnter() {
       saveProgress(currentSpineIndex, nextPageNumber, cachedChapterTotalPageCount);
     }
   }
-  // We may want a better condition to detect if we are opening for the first time.
-  // This will trigger if the book is re-opened at Chapter 0.
-  if (currentSpineIndex == 0) {
+  // Only apply the EPUB text reference on first open; a saved position in spine 0 is valid progress.
+  if (!loadedProgress && currentSpineIndex == 0) {
     int textSpineIndex = epub->getSpineIndexForTextReference();
     if (textSpineIndex != 0) {
       currentSpineIndex = textSpineIndex;

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -124,7 +124,7 @@ uint8_t getBookProgressPercent(const RecentBook& recentBook) {
   if (stats == nullptr) {
     return 0;
   }
-  return stats->completed ? 100 : std::min<uint8_t>(stats->lastProgressPercent, 100);
+  return std::min<uint8_t>(stats->lastProgressPercent, 100);
 }
 
 void drawProgressBadge(GfxRenderer& renderer, const RecentBook& book, const int coverX, const int coverY,


### PR DESCRIPTION
## Summary
**TL;DR:**
- Preserves valid EPUB progress saved in spine 0.
- Shows the actual current carousel progress badge instead of forcing completed books to 100%.
- Supersedes #53 by carrying the same carousel progress badge commit plus the EPUB spine-0 resume fix.

**Goal:** Keep reader resume and home progress display behavior accurate on the ESP32-C3 without changing cache formats, adding extra SD writes, or adding runtime allocation.

This PR combines two closely related progress fixes. #53 only fixed the carousel progress badge display. This PR includes that same commit, then adds the reader-side fix for EPUBs where saved progress in spine 0 was incorrectly treated as first-open state.

---

## Changes

### Carousel Progress Badge
**1. Show saved current progress instead of completion override** (`src/activities/home/HomeActivity.cpp`, `src/components/themes/lyra/LyraCarouselTheme.cpp`)

The Lyra carousel now displays `lastProgressPercent` directly, capped at 100, instead of showing `100%` whenever reading stats mark a book as completed. This makes the badge reflect the current saved progress position.

### EPUB Progress Restore
**2. Guard first-open text-reference navigation** (`src/activities/reader/EpubReaderActivity.cpp`)

Tracks whether a valid 4-byte or 6-byte progress record was loaded before applying the EPUB text-reference jump. This preserves real saved positions in spine 0 while keeping the original first-open behavior when no saved progress exists.

---

## File summary
| File | What changed |
|---|---|
| `src/activities/home/HomeActivity.cpp` | Uses saved `lastProgressPercent` for carousel progress instead of forcing completed books to 100%. |
| `src/components/themes/lyra/LyraCarouselTheme.cpp` | Applies the same progress badge behavior in the Lyra carousel theme path. |
| `src/activities/reader/EpubReaderActivity.cpp` | Adds a `loadedProgress` guard so saved spine-0 EPUB positions are not overwritten by first-open text-reference logic. |

---

## Testing performed
| Scenario | Result |
|---|---|
| Branch compare against `master` | TBD |
| Confirm #54 contains #53 commit `ffdef97400350aca2c83b3362c537e50a5ff8b7b` | ✅ |
| Confirm #54 adds EPUB spine-0 commit `940d89b54c85009f96c4e4e7915c54c2144a57eb` | ✅ |
| Build firmware with PlatformIO default environment | ✅ |
| Reopen EPUB with saved progress in spine 0 | ✅ |
| Check Lyra carousel progress badge for completed/reopened book | ✅ |

---

### AI Usage
Did you use AI tools to help write this code? **YES**