### PR TITLE
fix: restore carousel after recents cancel

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -934,8 +934,12 @@ void HomeActivity::loop() {
             std::make_unique<ConfirmationActivity>(renderer, mappedInput, I18N.get(confirmationPrompt),
                                                    getRecentBookConfirmationLabel(selectedBook)),
             [this, selectedBook, currentSelection, deleteFromFavorites](const ActivityResult& result) {
+              if (isLyraCarouselTheme()) {
+                invalidateResidentCarouselFrame();
+              }
+
               if (result.isCancelled) {
-                requestUpdate();
+                requestUpdate(true);
                 return;
               }
 


### PR DESCRIPTION
## Summary
**TL;DR:**
- Fixes a Lyra Carousel ghost-screen state after cancelling the Home delete-from-recents confirmation.
- Invalidates Home's resident carousel frame marker when returning from the confirmation screen.
- Forces the cancel path to repaint immediately so the cached carousel frame is restored into the framebuffer.

**Goal:** Prevent stale confirmation text from remaining on the Xteink X4 e-ink screen after cancelling a recents deletion prompt, while keeping the fix narrow for ESP32-C3 memory limits and e-ink refresh behavior.

The issue happened because the confirmation activity overwrote the framebuffer, but Home still believed its carousel frame was resident and valid.

---

## Changes
### Carousel Prompt Recovery
**1. Invalidate resident carousel frame** (`src/activities/home/HomeActivity.cpp`)
Home now invalidates the Lyra Carousel resident frame marker as soon as the delete confirmation returns.

**2. Repaint cancelled confirmation immediately** (`src/activities/home/HomeActivity.cpp`)
The cancel path now requests an immediate update so the prompt is cleared promptly.

---

## Testing performed
| Scenario | Result |
|---|---|
| Branch compare against `master` | ✅ Branch pushed for compare |
| Long-press Select on a carousel book, cancel “Delete from recents?”, no ghosting | ✅ Verified by user on device |
| `git diff --check` | ✅ Passed, only LF-to-CRLF warning |

---

### AI Usage
Did you use AI tools to help write this code? **Partial**