### PR TITLE
fix: flash website was not doing the automatic reboot of device

### DIFF
--- a/docs/flash.html
+++ b/docs/flash.html
@@ -867,8 +867,25 @@ pio run -e gh_release -t upload</code></pre>
         });
 
         await runStep("reset", async () => {
-          await disconnectLoader(loader, false);
+          // esptool-js 0.5.7's usbJTAGSerialReset.reset() is broken for native USB
+          // (pid 0x1001): its entire body is `wait 200ms → setRTS(false) → wait 200ms`.
+          // Since RTS is already false after the bootloader-entry sequence, this is a
+          // no-op and the device never resets. Bypass loader.after() and implement
+          // esptool.py's hard_reset() directly: setRTS(true) → 100ms → setRTS(false).
+          if (currentTransport) {
+            try {
+              await currentTransport.setDTR(false); // IO0 high → normal boot (not download mode)
+              await currentTransport.setRTS(true);  // EN low → assert reset
+              await new Promise(r => setTimeout(r, 100));
+              await currentTransport.setRTS(false); // EN high → release, device boots
+              await new Promise(r => setTimeout(r, 400));
+            } catch (_) {}
+          }
           loader = null;
+          if (currentTransport) {
+            try { await currentTransport.disconnect(); } catch (_) {}
+            currentTransport = null;
+          }
         });
 
         setStatus(siteT("flashComplete"), "success");


### PR DESCRIPTION
## Summary
**TL;DR:**
- After a successful firmware write the Xteink X3/X4 stayed in ROM bootloader instead of rebooting into CPR-vCodex, even though the UI showed "Flash complete".
- esptool-js 0.5.7 automatically selects `usbJTAGSerialReset` for native USB devices (pid `0x1001`), but its `reset()` body is entirely `wait 200ms → setRTS(false) → wait 200ms` — a no-op since RTS is already `false` after the bootloader-entry sequence.
- The fix bypasses `loader.after()` and implements esptool.py's `hard_reset()` directly on the transport (`setDTR(false)` → `setRTS(true)` → 100 ms → `setRTS(false)`), restoring automatic reboot on flash completion.

**Goal:** Ensure the Xteink X3/X4 (ESP32-C3 native USB, pid `0x303a:0x1001`) automatically reboots into CPR-vCodex at the end of a successful browser flash, matching the behavior PlatformIO's esptool.py already provides.

After a complete and error-free flash via the auto-flash page, the device remained in ROM bootloader mode — no reboot occurred and the user had to power-cycle manually. Investigation showed:
- The esptool-js `Transport` identifies the device as a USB Serial/JTAG device (`pid === 0x1001`) and routes `after("hard_reset")` to the `usbJTAGSerialReset` reset class.
- That class's `reset()` method only calls `setRTS(false)` — the bootloader-entry sequence (`classicReset`) had already driven RTS low, so there is no toggle and no reset pulse reaches EN.
- esptool.py's `hard_reset()` asserts `setRTS(true)` first (EN low → reset), holds 100 ms, then releases (`setRTS(false)` → EN high → device boots). This is what PlatformIO does and it works correctly.

---

## Changes

### Fix

**1. Replace `loader.after("hard_reset")` with a direct RTS/DTR pulse** (`docs/flash.html`)
Bypasses the broken `usbJTAGSerialReset.reset()` entirely and drives the transport signals directly, mirroring esptool.py's `hard_reset()`: assert DTR low (IO0 high → normal boot mode), assert RTS high (EN low → reset), hold 100 ms, release RTS (EN high → device boots), then settle 400 ms. This is wrapped in `try/catch` since the USB device may disconnect mid-sequence as the chip resets.

**2. Move transport disconnect inline into the reset step** (`docs/flash.html`)
Previously `disconnectLoader(loader, false)` handled both the reset signal and the port close. With `loader.after()` bypassed, port cleanup is now done directly at the end of the reset step, nulling `currentTransport` explicitly so the `startFlash` finally block's `disconnectLoader` guard (`if (loader || currentTransport)`) correctly skips a redundant disconnect on success.

---

## File summary

| File | What changed |
|---|---|
| `docs/flash.html` | Reset step rewritten to bypass esptool-js's broken `usbJTAGSerialReset`; direct RTS/DTR toggle added matching esptool.py's `hard_reset()`; transport disconnect moved inline |

---

## Testing performed

| Scenario | Result |
|---|---|
| Branch compare against `master` | ✅ |
| Flash firmware to Xteink X4 via browser auto-flash page (Chrome, local dev server) | ✅ |
| Device reboots automatically into CPR-vCodex after flash completes | ✅ |
| UI shows "Flash complete" (green) with no error box after reboot | ✅ |

*Testing performed on-device against an Xteink X4 over native USB, served locally via `python -m http.server 8080` from the `docs/` directory.*

---

## Pending / Known limitations

### esptool-js 0.5.7 bug not reported upstream
The broken `usbJTAGSerialReset.reset()` is a library-level bug. This workaround patches over it locally; if esptool-js is upgraded to a version that corrects the class, the bypass should be removed and `disconnectLoader(loader, false)` restored. No version pin has been added to the unpkg import — the import URL should be checked when the library is next upgraded.

### Xteink X3 untested
The RTS/DTR reset sequence is identical for X3 and X4 (same ESP32-C3 native USB Serial/JTAG controller), but the fix was only physically verified on an X4.

---

### AI Usage
Did you use AI tools to help write this code? **YES**