### PR TITLE
feat(opds): save downloads to per-server subdirectory under /opds/

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1,6 +1,7 @@
 #include "OpdsBookBrowserActivity.h"
 
 #include <GfxRenderer.h>
+#include <HalStorage.h>
 #include <I18n.h>
 #include <Logging.h>
 #include <OpdsStream.h>
@@ -284,7 +285,13 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   // Build full download URL relative to the current feed, not the root server URL
   const std::string feedUrl = UrlUtils::buildUrl(server.url, currentPath);
   std::string downloadUrl = UrlUtils::buildUrl(feedUrl, book.href);
-  std::string filename = "/" + StringUtils::sanitizeFilename(buildOpdsDownloadBaseName(book)) + ".epub";
+  std::string opdsFolderName = server.name.empty() ? "default" : StringUtils::sanitizeFilename(server.name);
+  std::string opdsDir = "/opds/" + opdsFolderName;
+  if (!Storage.mkdir(opdsDir.c_str())) {
+    LOG_DBG("OPDS", "Failed to create directory %s, saving to root", opdsDir.c_str());
+    opdsDir = "";
+  }
+  std::string filename = opdsDir + "/" + StringUtils::sanitizeFilename(buildOpdsDownloadBaseName(book)) + ".epub";
   LOG_DBG("OPDS", "Downloading: %s -> %s", downloadUrl.c_str(), filename.c_str());
 
   const auto result = HttpDownloader::downloadToFile(


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Routes OPDS book downloads into per-server subdirectories under /opds/<server-name>/ instead of dumping everything at the SD card root.

* **What changes are included?** OpdsBookBrowserActivity: derives folder name from server name (sanitized), creates /opds/<name>/ via Storage.mkdir, falls back to root if mkdir fails, then builds the full download path.

## Additional Context

Server name is sanitized with the existing StringUtils::sanitizeFilename — same logic used for filenames.
If the server has no name, folder defaults to default.
mkdir failure is non-fatal: logs a debug message and falls back to root download path, so existing behavior is preserved on storage errors.
No settings change, no migration needed.

---

### AI Usage

Did you use AI tools to help write this code? _**< YES >**_
