### PR TITLE
fix(reader): stream grayscale rendering in tiled bands

### DIFF
--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -78,7 +78,7 @@ void TextBlock::recordFontUsage(FontCacheManager& fontCacheManager, const int fo
     const EpdFontFamily::Style style = wordStyles[i];
     fontCacheManager.recordText(words[i].c_str(), fontId, style);
     if (bionicReadingMode == BIONIC_READING_NORMAL && (style & EpdFontFamily::BOLD) == 0) {
-      fontCacheManager.recordStyle(fontId, static_cast<EpdFontFamily::Style>(style | EpdFontFamily::BOLD));
+      fontCacheManager.recordText(" ", fontId, static_cast<EpdFontFamily::Style>(style | EpdFontFamily::BOLD));
     }
   }
 }

--- a/lib/Epub/Epub/converters/DirectPixelWriter.h
+++ b/lib/Epub/Epub/converters/DirectPixelWriter.h
@@ -17,6 +17,10 @@ struct DirectPixelWriter {
   GfxRenderer::RenderMode mode;
   bool darkMode;
   uint16_t displayWidthBytes;  // Runtime framebuffer stride (X4: 100, X3: 99)
+  // Active write target: for tiled grayscale, fb is the band scratch, originY is
+  // the band's top physical row, and clipRows is the band height.
+  int originY;
+  int clipRows;
 
   // Orientation is collapsed into a linear transform:
   //   phyX = phyXBase + x * phyXStepX + y * phyXStepY
@@ -29,7 +33,9 @@ struct DirectPixelWriter {
   int rowPhyXBase, rowPhyYBase;
 
   void init(GfxRenderer& renderer) {
-    fb = renderer.getFrameBuffer();
+    fb = renderer.getWriteTarget();
+    originY = renderer.getWriteOriginY();
+    clipRows = renderer.getWriteRows();
     mode = renderer.getRenderMode();
     darkMode = renderer.isDarkMode();
     displayWidthBytes = renderer.getDisplayWidthBytes();
@@ -93,14 +99,34 @@ struct DirectPixelWriter {
     rowPhyYBase = phyYBase + logicalY * phyYStepY;
   }
 
-  // For the current row (set via beginRow), narrow [colStart, colEnd) to the
-  // active output band. CPR-vCodex renders grayscale against a full framebuffer,
-  // so every column remains active here. Upstream tiled renderers override this
-  // with a narrower range.
   inline void bandColRange(int xBase, int width, int& colStart, int& colEnd) const {
-    (void)xBase;
     colStart = 0;
     colEnd = width;
+
+    const int bandMin = originY;
+    const int bandMax = originY + clipRows - 1;
+    if (phyYStepX == 0) {
+      if (rowPhyYBase < bandMin || rowPhyYBase > bandMax) {
+        colEnd = 0;
+      }
+      return;
+    }
+
+    int minCol;
+    int maxCol;
+    if (phyYStepX > 0) {
+      minCol = bandMin - rowPhyYBase - xBase;
+      maxCol = bandMax - rowPhyYBase - xBase;
+    } else {
+      minCol = rowPhyYBase - bandMax - xBase;
+      maxCol = rowPhyYBase - bandMin - xBase;
+    }
+
+    if (minCol > colStart) colStart = minCol;
+    if (maxCol + 1 < colEnd) colEnd = maxCol + 1;
+    if (colStart < 0) colStart = 0;
+    if (colEnd > width) colEnd = width;
+    if (colStart > colEnd) colStart = colEnd;
   }
 
   // Write a single 2-bit dithered pixel value to the framebuffer.
@@ -132,7 +158,12 @@ struct DirectPixelWriter {
     const int phyX = rowPhyXBase + logicalX * phyXStepX;
     const int phyY = rowPhyYBase + logicalX * phyYStepX;
 
-    const uint16_t byteIndex = phyY * displayWidthBytes + (phyX >> 3);
+    // Band-local row. The unsigned compare drops both off-band pixels (strip
+    // mode) and any out-of-frame row (full-frame mode) in one branch.
+    const int sy = phyY - originY;
+    if (static_cast<unsigned>(sy) >= static_cast<unsigned>(clipRows)) return;
+
+    const uint16_t byteIndex = static_cast<uint16_t>(sy * displayWidthBytes + (phyX >> 3));
     const uint8_t bitMask = 1 << (7 - (phyX & 7));
 
     if (state) {

--- a/lib/GfxRenderer/FontCacheManager.cpp
+++ b/lib/GfxRenderer/FontCacheManager.cpp
@@ -74,12 +74,6 @@ void FontCacheManager::recordText(const char* text, int fontId, EpdFontFamily::S
   scanStyleCounts_[baseStyle] += cpCount;
 }
 
-void FontCacheManager::recordStyle(int fontId, EpdFontFamily::Style style) {
-  if (scanFontId_ < 0) scanFontId_ = fontId;
-  const uint8_t baseStyle = static_cast<uint8_t>(style) & 0x03;
-  scanStyleCounts_[baseStyle] += 1;
-}
-
 // --- PrewarmScope implementation ---
 
 FontCacheManager::PrewarmScope::PrewarmScope(FontCacheManager& manager) : manager_(&manager) {
@@ -105,9 +99,7 @@ void FontCacheManager::PrewarmScope::endScanAndPrewarm() {
 
   manager_->prewarmCache(manager_->scanFontId_, manager_->scanText_.c_str(), styleMask);
 
-  // Free scan string memory
   manager_->scanText_.clear();
-  manager_->scanText_.shrink_to_fit();
 }
 
 FontCacheManager::PrewarmScope::~PrewarmScope() {

--- a/lib/GfxRenderer/FontCacheManager.h
+++ b/lib/GfxRenderer/FontCacheManager.h
@@ -23,7 +23,6 @@ class FontCacheManager {
   // Scan-mode API: called by GfxRenderer::drawText() during scan pass
   bool isScanning() const;
   void recordText(const char* text, int fontId, EpdFontFamily::Style style);
-  void recordStyle(int fontId, EpdFontFamily::Style style);
 
   // The FontDecompressor pointer, needed by GfxRenderer::getGlyphBitmap()
   FontDecompressor* getDecompressor() const { return fontDecompressor_; }

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -5,6 +5,7 @@
 #include <Logging.h>
 #include <SdCardFont.h>
 #include <Utf8.h>
+#include <freertos/task.h>
 
 #include <algorithm>
 #include <climits>
@@ -99,6 +100,75 @@ void GfxRenderer::begin() {
   panelWidthBytes = display.getDisplayWidthBytes();
   frameBufferSize = display.getBufferSize();
   bwBufferChunks.assign((frameBufferSize + BW_BUFFER_CHUNK_SIZE - 1) / BW_BUFFER_CHUNK_SIZE, nullptr);
+  if (!bitmapScratchMutex_) {
+    bitmapScratchMutex_ = xSemaphoreCreateMutex();
+  }
+}
+
+GfxRenderer::BitmapScratchLock::BitmapScratchLock(const GfxRenderer& renderer) : renderer_(renderer) {
+  if (renderer_.bitmapScratchMutex_ == nullptr) {
+    LOG_ERR("GFX", "!! Bitmap scratch mutex is not initialized");
+    assert(false);
+    return;
+  }
+
+  const auto takeResult = xSemaphoreTake(renderer_.bitmapScratchMutex_, portMAX_DELAY);
+  if (takeResult != pdTRUE) {
+    LOG_ERR("GFX", "!! Failed to acquire bitmap scratch mutex");
+    assert(false);
+    return;
+  }
+  locked_ = true;
+}
+
+GfxRenderer::BitmapScratchLock::~BitmapScratchLock() {
+  if (!locked_) return;
+  xSemaphoreGive(renderer_.bitmapScratchMutex_);
+}
+
+void GfxRenderer::freeBitmapScratchBuffers() {
+  free(bitmapScratchOutputRow_);
+  bitmapScratchOutputRow_ = nullptr;
+  bitmapScratchOutputRowSize_ = 0;
+
+  free(bitmapScratchRowBytes_);
+  bitmapScratchRowBytes_ = nullptr;
+  bitmapScratchRowBytesSize_ = 0;
+}
+
+bool GfxRenderer::bitmapScratchLockHeldByCurrentTask() const {
+  if (bitmapScratchMutex_ == nullptr) return false;
+  return xSemaphoreGetMutexHolder(bitmapScratchMutex_) == xTaskGetCurrentTaskHandle();
+}
+
+bool GfxRenderer::ensureBitmapScratchBuffers(const size_t outputRowSize, const size_t rowBytesSize) const {
+  if (!bitmapScratchLockHeldByCurrentTask()) {
+    LOG_ERR("GFX", "!! Bitmap scratch buffers used without holding scratch mutex");
+    assert(false);
+    return false;
+  }
+
+  if (outputRowSize > bitmapScratchOutputRowSize_) {
+    auto* grownOutput = static_cast<uint8_t*>(realloc(bitmapScratchOutputRow_, outputRowSize));
+    if (!grownOutput) {
+      LOG_ERR("GFX", "!! Failed to grow BMP output row scratch buffer to %zu bytes", outputRowSize);
+      return false;
+    }
+    bitmapScratchOutputRow_ = grownOutput;
+    bitmapScratchOutputRowSize_ = outputRowSize;
+  }
+
+  if (rowBytesSize > bitmapScratchRowBytesSize_) {
+    auto* grownRowBytes = static_cast<uint8_t*>(realloc(bitmapScratchRowBytes_, rowBytesSize));
+    if (!grownRowBytes) {
+      LOG_ERR("GFX", "!! Failed to grow BMP row-bytes scratch buffer to %zu bytes", rowBytesSize);
+      return false;
+    }
+    bitmapScratchRowBytes_ = grownRowBytes;
+    bitmapScratchRowBytesSize_ = rowBytesSize;
+  }
+
+  return true;
 }
 
 bool GfxRenderer::isFontCacheScanning() const { return fontCacheManager_ && fontCacheManager_->isScanning(); }
@@ -245,6 +315,22 @@ static void renderCharImpl(const GfxRenderer& renderer, GfxRenderer::RenderMode 
   const int left = glyph->left;
   const int top = glyph->top;
 
+  // Tiled-grayscale band culling: if this glyph's physical y-extent is entirely
+  // outside the active strip, skip it before the expensive bitmap decode.
+  if constexpr (rotation == TextRotation::Rotated90CW) {
+    const int ob = cursorX + fontData->ascender - top;
+    const int ib = cursorY - left;
+    if (!renderer.glyphIntersectsStrip(ob, ib - (width - 1), ob + height - 1, ib)) {
+      return;
+    }
+  } else {
+    const int gx0 = cursorX + left;
+    const int gy0 = cursorY - top;
+    if (!renderer.glyphIntersectsStrip(gx0, gy0, gx0 + width - 1, gy0 + height - 1)) {
+      return;
+    }
+  }
+
   const uint8_t* bitmap = renderer.getGlyphBitmap(fontData, glyph);
 
   if (bitmap != nullptr) {
@@ -358,14 +444,26 @@ void GfxRenderer::drawPixelRaw(const int x, const int y, const bool state) const
     return;
   }
 
+  // Tiled grayscale: redirect writes to the strip scratch and clip to the
+  // current band. Single predictable branch on the hot per-pixel path.
+  uint8_t* target = frameBuffer;
+  uint32_t rowY = static_cast<uint32_t>(phyY);
+  if (_stripActive) {
+    if (phyY < _stripY0 || phyY >= _stripY0 + _stripRows) {
+      return;
+    }
+    target = _stripBuf;
+    rowY = static_cast<uint32_t>(phyY - _stripY0);
+  }
+
   // Calculate byte position and bit position
-  const uint32_t byteIndex = static_cast<uint32_t>(phyY) * panelWidthBytes + (phyX / 8);
+  const uint32_t byteIndex = rowY * panelWidthBytes + (phyX / 8);
   const uint8_t bitPosition = 7 - (phyX % 8);  // MSB first
 
   if (state) {
-    frameBuffer[byteIndex] &= ~(1 << bitPosition);  // Clear bit
+    target[byteIndex] &= ~(1 << bitPosition);  // Clear bit
   } else {
-    frameBuffer[byteIndex] |= 1 << bitPosition;  // Set bit
+    target[byteIndex] |= 1 << bitPosition;  // Set bit
   }
 }
 
@@ -943,18 +1041,17 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
   }
   LOG_DBG("GFX", "Scaling by %f - %s", scale, isScaled ? "scaled" : "not scaled");
 
+  BitmapScratchLock scratchLock(*this);
+  if (!scratchLock.isLocked()) return;
+
   // Calculate output row size (2 bits per pixel, packed into bytes)
   // IMPORTANT: Use int, not uint8_t, to avoid overflow for images > 1020 pixels wide
   const int outputRowSize = (bitmap.getWidth() + 3) / 4;
-  auto* outputRow = static_cast<uint8_t*>(malloc(outputRowSize));
-  auto* rowBytes = static_cast<uint8_t*>(malloc(bitmap.getRowBytes()));
-
-  if (!outputRow || !rowBytes) {
-    LOG_ERR("GFX", "!! Failed to allocate BMP row buffers");
-    free(outputRow);
-    free(rowBytes);
+  if (!ensureBitmapScratchBuffers(outputRowSize, bitmap.getRowBytes())) {
     return;
   }
+  auto* outputRow = bitmapScratchOutputRow_;
+  auto* rowBytes = bitmapScratchRowBytes_;
 
   for (int bmpY = 0; bmpY < (bitmap.getHeight() - cropPixY); bmpY++) {
     // The BMP's (0, 0) is the bottom-left corner (if the height is positive, top-left if negative).
@@ -970,8 +1067,6 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
 
     if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
       LOG_ERR("GFX", "Failed to read row %d from bitmap", bmpY);
-      free(outputRow);
-      free(rowBytes);
       return;
     }
 
@@ -1013,8 +1108,6 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
     }
   }
 
-  free(outputRow);
-  free(rowBytes);
 }
 
 void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y, const int maxWidth,
@@ -1030,24 +1123,21 @@ void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y,
     isScaled = true;
   }
 
+  BitmapScratchLock scratchLock(*this);
+  if (!scratchLock.isLocked()) return;
+
   // For 1-bit BMP, output is still 2-bit packed (for consistency with readNextRow)
   const int outputRowSize = (bitmap.getWidth() + 3) / 4;
-  auto* outputRow = static_cast<uint8_t*>(malloc(outputRowSize));
-  auto* rowBytes = static_cast<uint8_t*>(malloc(bitmap.getRowBytes()));
-
-  if (!outputRow || !rowBytes) {
-    LOG_ERR("GFX", "!! Failed to allocate 1-bit BMP row buffers");
-    free(outputRow);
-    free(rowBytes);
+  if (!ensureBitmapScratchBuffers(outputRowSize, bitmap.getRowBytes())) {
     return;
   }
+  auto* outputRow = bitmapScratchOutputRow_;
+  auto* rowBytes = bitmapScratchRowBytes_;
 
   for (int bmpY = 0; bmpY < bitmap.getHeight(); bmpY++) {
     // Read rows sequentially using readNextRow
     if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
       LOG_ERR("GFX", "Failed to read row %d from 1-bit bitmap", bmpY);
-      free(outputRow);
-      free(rowBytes);
       return;
     }
 
@@ -1082,8 +1172,6 @@ void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y,
     }
   }
 
-  free(outputRow);
-  free(rowBytes);
 }
 
 void GfxRenderer::fillPolygon(const int* xPoints, const int* yPoints, int numPoints, bool state) const {
@@ -1151,8 +1239,38 @@ static unsigned long start_ms = 0;
 
 void GfxRenderer::clearScreen(const uint8_t color) const {
   start_ms = millis();
+  if (_stripActive) {
+    memset(_stripBuf, color, static_cast<size_t>(panelWidthBytes) * _stripRows);
+    return;
+  }
   const uint8_t effectiveColor = (darkMode && renderMode == BW && color == 0xFF) ? 0x00 : color;
   display.clearScreen(effectiveColor);
+}
+
+void GfxRenderer::beginStripTarget(uint8_t* scratch, int stripY0, int stripRows) const {
+  _stripBuf = scratch;
+  _stripY0 = stripY0;
+  _stripRows = stripRows;
+  _stripActive = true;
+}
+
+void GfxRenderer::endStripTarget() const {
+  _stripActive = false;
+  _stripBuf = nullptr;
+  _stripY0 = 0;
+  _stripRows = 0;
+}
+
+bool GfxRenderer::glyphIntersectsStrip(int x0, int y0, int x1, int y1) const {
+  if (!_stripActive) {
+    return true;
+  }
+  int ax, ay, bx, by;
+  rotateCoordinates(orientation, x0, y0, &ax, &ay, panelWidth, panelHeight);
+  rotateCoordinates(orientation, x1, y1, &bx, &by, panelWidth, panelHeight);
+  const int minY = ay < by ? ay : by;
+  const int maxY = ay > by ? ay : by;
+  return !(maxY < _stripY0 || minY >= _stripY0 + _stripRows);
 }
 
 void GfxRenderer::invertScreen() const {
@@ -1599,7 +1717,15 @@ void GfxRenderer::copyGrayscaleLsbBuffers() const { display.copyGrayscaleLsbBuff
 
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }
 
-void GfxRenderer::displayGrayBuffer() const { display.displayGrayBuffer(fadingFix); }
+void GfxRenderer::displayGrayBuffer(const bool turnOffScreen) const {
+  display.displayGrayBuffer(fadingFix || turnOffScreen);
+}
+
+void GfxRenderer::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const {
+  display.writeGrayscalePlaneStrip(lsbPlane, scratch, static_cast<uint16_t>(yStart), static_cast<uint16_t>(numRows));
+}
+
+bool GfxRenderer::supportsStripGrayscale() const { return display.supportsStripGrayscale(); }
 
 void GfxRenderer::freeBwBufferChunks() {
   for (auto& bwBufferChunk : bwBufferChunks) {

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -2,6 +2,8 @@
 
 #include <EpdFontFamily.h>
 #include <HalDisplay.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 class FontCacheManager;
 class SdCardFont;
@@ -57,10 +59,28 @@ class GfxRenderer {
   mutable bool nextRefreshOverridePending = false;
   mutable HalDisplay::RefreshMode nextRefreshOverride = HalDisplay::FAST_REFRESH;
 
+  // Tiled grayscale strip target. When active, drawPixel()/clearScreen()
+  // operate on a caller-owned scratch holding one horizontal band of physical
+  // rows [_stripY0, _stripY0 + _stripRows) instead of the shared framebuffer.
+  mutable uint8_t* _stripBuf = nullptr;
+  mutable int _stripY0 = 0;
+  mutable int _stripRows = 0;
+  mutable bool _stripActive = false;
+
   // Mutable because drawText() is const but needs to delegate scan-mode
   // recording to the (non-const) FontCacheManager. Same pragmatic compromise
   // as before, concentrated in a single pointer instead of four fields.
   mutable FontCacheManager* fontCacheManager_ = nullptr;
+
+  // Shared bitmap row scratch buffers (pooled to avoid per-draw malloc/free).
+  mutable SemaphoreHandle_t bitmapScratchMutex_ = nullptr;
+  mutable uint8_t* bitmapScratchOutputRow_ = nullptr;
+  mutable size_t bitmapScratchOutputRowSize_ = 0;
+  mutable uint8_t* bitmapScratchRowBytes_ = nullptr;
+  mutable size_t bitmapScratchRowBytesSize_ = 0;
+  bool bitmapScratchLockHeldByCurrentTask() const;
+  bool ensureBitmapScratchBuffers(size_t outputRowSize, size_t rowBytesSize) const;
+  void freeBitmapScratchBuffers();
 
   void renderChar(const EpdFontFamily& fontFamily, uint32_t cp, int* x, int* y, bool pixelState,
                   EpdFontFamily::Style style) const;
@@ -74,7 +94,23 @@ class GfxRenderer {
  public:
   explicit GfxRenderer(HalDisplay& halDisplay)
       : display(halDisplay), renderMode(BW), orientation(Portrait), fadingFix(false), darkMode(false) {}
-  ~GfxRenderer() { freeBwBufferChunks(); }
+  ~GfxRenderer() {
+    freeBwBufferChunks();
+    freeBitmapScratchBuffers();
+  }
+
+  class BitmapScratchLock {
+   public:
+    explicit BitmapScratchLock(const GfxRenderer& renderer);
+    ~BitmapScratchLock();
+    bool isLocked() const { return locked_; }
+    BitmapScratchLock(const BitmapScratchLock&) = delete;
+    BitmapScratchLock& operator=(const BitmapScratchLock&) = delete;
+
+   private:
+    const GfxRenderer& renderer_;
+    bool locked_ = false;
+  };
 
   static constexpr int VIEWABLE_MARGIN_TOP = 9;
   static constexpr int VIEWABLE_MARGIN_RIGHT = 3;
@@ -128,6 +164,14 @@ class GfxRenderer {
   void invertScreen() const;
   void clearScreen(uint8_t color = 0xFF) const;
   void getOrientedViewableTRBL(int* outTop, int* outRight, int* outBottom, int* outLeft) const;
+
+  // Tiled grayscale strip targeting
+  void beginStripTarget(uint8_t* scratch, int stripY0, int stripRows) const;
+  void endStripTarget() const;
+  bool glyphIntersectsStrip(int x0, int y0, int x1, int y1) const;
+  uint8_t* getWriteTarget() const { return _stripActive ? _stripBuf : frameBuffer; }
+  int getWriteOriginY() const { return _stripActive ? _stripY0 : 0; }
+  int getWriteRows() const { return _stripActive ? _stripRows : panelHeight; }
 
   // Drawing
   void drawPixel(int x, int y, bool state = true) const;
@@ -189,7 +233,9 @@ class GfxRenderer {
   RenderMode getRenderMode() const { return renderMode; }
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
-  void displayGrayBuffer() const;
+  void displayGrayBuffer(bool turnOffScreen = false) const;
+  void writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const;
+  bool supportsStripGrayscale() const;
   bool storeBwBuffer();    // Returns true if buffer was stored successfully
   void restoreBwBuffer();  // Restore and free the stored buffer
   void cleanupGrayscaleWithFrameBuffer() const;

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -1,6 +1,8 @@
 #include <HalDisplay.h>
 #include <HalGPIO.h>
 
+#include "HalSpiBus.h"
+
 // Global HalDisplay instance
 HalDisplay display;
 
@@ -11,6 +13,8 @@ HalDisplay::HalDisplay() : einkDisplay(EPD_SCLK, EPD_MOSI, EPD_CS, EPD_DC, EPD_R
 HalDisplay::~HalDisplay() {}
 
 void HalDisplay::begin(bool seamless) {
+  HalSpiBus::Lock spiLock;
+
   // Set X3-specific panel mode before initializing.
   if (gpio.deviceIsX3()) {
     einkDisplay.setDisplayX3();
@@ -56,6 +60,8 @@ EInkDisplay::RefreshMode convertRefreshMode(HalDisplay::RefreshMode mode) {
 }
 
 void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+
   if (gpio.deviceIsX3() && mode == RefreshMode::HALF_REFRESH) {
     einkDisplay.requestResync(1);
   }
@@ -64,6 +70,8 @@ void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen)
 }
 
 void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+
   if (gpio.deviceIsX3() && mode == RefreshMode::HALF_REFRESH) {
     einkDisplay.requestResync(1);
   }
@@ -71,7 +79,10 @@ void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen
   einkDisplay.refreshDisplay(convertRefreshMode(mode), turnOffScreen);
 }
 
-void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
+void HalDisplay::deepSleep() {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.deepSleep();
+}
 
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
@@ -85,7 +96,18 @@ void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { einkDisplay
 
 void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.cleanupGrayscaleBuffers(bwBuffer); }
 
-void HalDisplay::displayGrayBuffer(bool turnOffScreen) { einkDisplay.displayGrayBuffer(turnOffScreen); }
+void HalDisplay::displayGrayBuffer(bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.displayGrayBuffer(turnOffScreen);
+}
+
+void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows) {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.writeGrayscalePlaneStrip(lsbPlane ? EInkDisplay::GRAY_PLANE_LSB : EInkDisplay::GRAY_PLANE_MSB, rows,
+                                       yStart, numRows);
+}
+
+bool HalDisplay::supportsStripGrayscale() const { return einkDisplay.supportsStripGrayscale(); }
 
 uint16_t HalDisplay::getDisplayWidth() const { return einkDisplay.getDisplayWidth(); }
 

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -51,6 +51,12 @@ class HalDisplay {
 
   void displayGrayBuffer(bool turnOffScreen = false);
 
+  // Tiled grayscale: stream one band of a plane (lsbPlane selects LSB/MSB RAM)
+  // straight to the controller; supportsStripGrayscale() gates the path. See
+  // EInkDisplay::writeGrayscalePlaneStrip.
+  void writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows);
+  bool supportsStripGrayscale() const;
+
   // Runtime geometry passthrough
   uint16_t getDisplayWidth() const;
   uint16_t getDisplayHeight() const;

--- a/lib/hal/HalSpiBus.cpp
+++ b/lib/hal/HalSpiBus.cpp
@@ -1,0 +1,34 @@
+#include "HalSpiBus.h"
+
+#include <Logging.h>
+
+HalSpiBus::HalSpiBus() {
+  mutex = xSemaphoreCreateRecursiveMutex();
+  if (mutex == nullptr) {
+    LOG_ERR("SPI", "Failed to create SPI bus mutex - bus is unusable");
+  }
+}
+
+HalSpiBus& HalSpiBus::getInstance() {
+  static HalSpiBus spiBus;
+  return spiBus;
+}
+
+HalSpiBus::Lock::Lock() {
+  auto& bus = HalSpiBus::getInstance();
+  if (bus.mutex == nullptr) {
+    LOG_ERR("SPI", "SPI bus mutex not initialized, skipping lock");
+    return;
+  }
+  const BaseType_t takeResult = xSemaphoreTakeRecursive(bus.mutex, portMAX_DELAY);
+  if (takeResult != pdTRUE) {
+    LOG_ERR("SPI", "Failed to acquire SPI bus mutex");
+    return;
+  }
+  acquired = true;
+}
+
+HalSpiBus::Lock::~Lock() {
+  if (!acquired) return;
+  xSemaphoreGiveRecursive(HalSpiBus::getInstance().mutex);
+}

--- a/lib/hal/HalSpiBus.h
+++ b/lib/hal/HalSpiBus.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+class HalSpiBus {
+ public:
+  class Lock {
+   public:
+    Lock();
+    ~Lock();
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+
+   private:
+    bool acquired = false;
+  };
+
+  static HalSpiBus& getInstance();
+
+ private:
+  HalSpiBus();
+
+  SemaphoreHandle_t mutex = nullptr;
+
+  friend class Lock;
+};

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -10,8 +10,10 @@
 #include <Logging.h>
 #include <MemoryBudget.h>
 
+#include <algorithm>
 #include <iterator>
 #include <limits>
+#include <memory>
 
 #include "AchievementsStore.h"
 #include "BookmarksActivity.h"
@@ -55,6 +57,67 @@ int clampPercent(int percent) {
     return 100;
   }
   return percent;
+}
+
+struct TiledGrayscaleTimings {
+  unsigned long grayLsb = 0;
+  unsigned long grayMsb = 0;
+  unsigned long grayDisplay = 0;
+  unsigned long cleanup = 0;
+};
+
+// Stream grayscale planes to the EPD controller in 80-row bands instead of
+// storing+restoring a full 48KB BW backup.  Uses only ~8KB scratch, never
+// touches the live BW framebuffer, and culls glyphs outside each band for
+// speed.  Returns false (without side-effects) when the strip path is
+// unavailable or the scratch allocation fails; the caller should fall back to
+// the legacy full-frame approach.
+bool runTiledGrayscalePass(GfxRenderer& renderer, const Page& page, const int fontId, const int marginLeft,
+                           const int marginTop, const uint8_t bionicReading, const bool needsTextGrayscale,
+                           const bool needsImageGrayscale, TiledGrayscaleTimings& timings) {
+  if ((!needsTextGrayscale && !needsImageGrayscale) || !renderer.supportsStripGrayscale()) {
+    return false;
+  }
+
+  constexpr int STRIP_ROWS = 80;
+  const int displayHeight = renderer.getDisplayHeight();
+  const int displayWidthBytes = renderer.getDisplayWidthBytes();
+  auto scratch =
+      std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[static_cast<size_t>(displayWidthBytes) * STRIP_ROWS]);
+  if (!scratch) {
+    LOG_ERR("ERS", "OOM: grayscale strip scratch (%d bytes); falling back to full-frame",
+            displayWidthBytes * STRIP_ROWS);
+    return false;
+  }
+
+  const auto renderPlane = [&](const GfxRenderer::RenderMode mode, const bool lsbPlane) {
+    renderer.setRenderMode(mode);
+    for (int y = 0; y < displayHeight; y += STRIP_ROWS) {
+      const int rows = std::min(STRIP_ROWS, displayHeight - y);
+      renderer.beginStripTarget(scratch.get(), y, rows);
+      renderer.clearScreen(0x00);
+      if (needsTextGrayscale) {
+        page.render(renderer, fontId, marginLeft, marginTop, bionicReading);
+      } else {
+        page.renderImages(renderer, marginLeft, marginTop);
+      }
+      renderer.endStripTarget();
+      renderer.writeGrayscalePlaneStrip(lsbPlane, scratch.get(), y, rows);
+    }
+  };
+
+  renderPlane(GfxRenderer::GRAYSCALE_LSB, true);
+  timings.grayLsb = millis();
+
+  renderPlane(GfxRenderer::GRAYSCALE_MSB, false);
+  timings.grayMsb = millis();
+
+  renderer.setRenderMode(GfxRenderer::BW);
+  renderer.displayGrayBuffer();
+  timings.grayDisplay = millis();
+  renderer.cleanupGrayscaleWithFrameBuffer();
+  timings.cleanup = millis();
+  return true;
 }
 
 std::string getStatsChapterTitle(Epub& epub, const int spineIndex) {
@@ -1515,64 +1578,85 @@ void EpubReaderActivity::renderContents(std::shared_ptr<Page> page, const int or
 
   const bool needsGrayscale = enableTextAA || enableImageGrayscaleOnly;
 
-  // Save BW buffer to reset framebuffer and controller state after grayscale data sync.
-  const auto bwStoreHeapBefore = MemoryBudget::snapshot();
-  const bool storedBwBuffer = needsGrayscale && renderer.storeBwBuffer();
-  const auto bwStoreHeapAfter = MemoryBudget::snapshot();
-  const auto tBwStore = millis();
-  if (needsGrayscale && !storedBwBuffer) {
-    LOG_ERR("ERS", "Skipping grayscale enhancement: failed to store BW backup (free=%u maxAlloc=%u before=%u/%u)",
-            bwStoreHeapAfter.freeHeap, bwStoreHeapAfter.maxAllocHeap, bwStoreHeapBefore.freeHeap,
-            bwStoreHeapBefore.maxAllocHeap);
+  // Grayscale rendering: try the tiled strip path first (8KB scratch, no BW
+  // backup needed), then fall back to the legacy full-frame path if it fails.
+  bool grayscaleDone = false;
+  if (needsGrayscale) {
+    TiledGrayscaleTimings tiledTimings;
+    const auto tGrayStart = millis();
+    grayscaleDone = runTiledGrayscalePass(renderer, *page, SETTINGS.getReaderFontId(), orientedMarginLeft,
+                                          orientedMarginTop, SETTINGS.bionicReading, enableTextAA,
+                                          enableImageGrayscaleOnly, tiledTimings);
+    if (grayscaleDone) {
+      fcm->logStats("gray-tiled");
+      const auto tEnd = millis();
+      LOG_DBG("ERS",
+              "Page render: prewarm=%lums bw_render=%lums display=%lums "
+              "gray_lsb=%lums gray_msb=%lums gray_display=%lums gray_cleanup=%lums total=%lums (tiled)",
+              tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tiledTimings.grayLsb - tGrayStart,
+              tiledTimings.grayMsb - tiledTimings.grayLsb, tiledTimings.grayDisplay - tiledTimings.grayMsb,
+              tiledTimings.cleanup - tiledTimings.grayDisplay, tEnd - t0);
+    }
   }
 
-  // grayscale rendering
-  // TODO: Only do this if font supports it
-  if (needsGrayscale && storedBwBuffer) {
-    renderer.clearScreen(0x00);
-    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-    if (enableImageGrayscaleOnly) {
-      page->renderImages(renderer, orientedMarginLeft, orientedMarginTop);
+  // Legacy full-frame grayscale fallback: store 48KB BW → clear → render LSB →
+  // copy → clear → render MSB → copy → display → restore BW.
+  if (needsGrayscale && !grayscaleDone) {
+    const auto bwStoreHeapBefore = MemoryBudget::snapshot();
+    const bool storedBwBuffer = renderer.storeBwBuffer();
+    const auto bwStoreHeapAfter = MemoryBudget::snapshot();
+    const auto tBwStore = millis();
+    if (!storedBwBuffer) {
+      LOG_ERR("ERS", "Skipping grayscale enhancement: failed to store BW backup (free=%u maxAlloc=%u before=%u/%u)",
+              bwStoreHeapAfter.freeHeap, bwStoreHeapAfter.maxAllocHeap, bwStoreHeapBefore.freeHeap,
+              bwStoreHeapBefore.maxAllocHeap);
     } else {
-      page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop, SETTINGS.bionicReading);
+      renderer.clearScreen(0x00);
+      renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+      if (enableImageGrayscaleOnly) {
+        page->renderImages(renderer, orientedMarginLeft, orientedMarginTop);
+      } else {
+        page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop,
+                     SETTINGS.bionicReading);
+      }
+      renderStatusBar();
+      renderer.copyGrayscaleLsbBuffers();
+      const auto tGrayLsb = millis();
+
+      renderer.clearScreen(0x00);
+      renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+      if (enableImageGrayscaleOnly) {
+        page->renderImages(renderer, orientedMarginLeft, orientedMarginTop);
+      } else {
+        page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop,
+                     SETTINGS.bionicReading);
+      }
+      renderStatusBar();
+      renderer.copyGrayscaleMsbBuffers();
+      const auto tGrayMsb = millis();
+
+      renderer.displayGrayBuffer();
+      const auto tGrayDisplay = millis();
+      renderer.setRenderMode(GfxRenderer::BW);
+      fcm->logStats("gray");
+
+      renderer.restoreBwBuffer();
+      const auto tBwRestore = millis();
+
+      const auto tEnd = millis();
+      LOG_DBG("ERS",
+              "Page render: prewarm=%lums bw_render=%lums display=%lums bw_store=%lums "
+              "gray_lsb=%lums gray_msb=%lums gray_display=%lums bw_restore=%lums total=%lums (full-frame)",
+              tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tBwStore - tDisplay, tGrayLsb - tBwStore,
+              tGrayMsb - tGrayLsb, tGrayDisplay - tGrayMsb, tBwRestore - tGrayDisplay, tEnd - t0);
+      grayscaleDone = true;
     }
-    renderStatusBar();
-    renderer.copyGrayscaleLsbBuffers();
-    const auto tGrayLsb = millis();
+  }
 
-    // Render and copy to MSB buffer
-    renderer.clearScreen(0x00);
-    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-    if (enableImageGrayscaleOnly) {
-      page->renderImages(renderer, orientedMarginLeft, orientedMarginTop);
-    } else {
-      page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop, SETTINGS.bionicReading);
-    }
-    renderStatusBar();
-    renderer.copyGrayscaleMsbBuffers();
-    const auto tGrayMsb = millis();
-
-    // display grayscale part
-    renderer.displayGrayBuffer();
-    const auto tGrayDisplay = millis();
-    renderer.setRenderMode(GfxRenderer::BW);
-    fcm->logStats("gray");
-
-    // restore the bw data
-    renderer.restoreBwBuffer();
-    const auto tBwRestore = millis();
-
+  if (!grayscaleDone) {
     const auto tEnd = millis();
-    LOG_DBG("ERS",
-            "Page render: prewarm=%lums bw_render=%lums display=%lums bw_store=%lums "
-            "gray_lsb=%lums gray_msb=%lums gray_display=%lums bw_restore=%lums total=%lums",
-            tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tBwStore - tDisplay, tGrayLsb - tBwStore,
-            tGrayMsb - tGrayLsb, tGrayDisplay - tGrayMsb, tBwRestore - tGrayDisplay, tEnd - t0);
-  } else {
-    const auto tEnd = millis();
-    LOG_DBG("ERS", "Page render: prewarm=%lums bw_render=%lums display=%lums bw_store=%lums grayscale=%s total=%lums",
-            tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tBwStore - tDisplay,
-            needsGrayscale ? "skipped" : "off", tEnd - t0);
+    LOG_DBG("ERS", "Page render: prewarm=%lums bw_render=%lums display=%lums grayscale=%s total=%lums", tPrewarm - t0,
+            tBwRender - tPrewarm, tDisplay - tBwRender, needsGrayscale ? "skipped" : "off", tEnd - t0);
   }
 }
 


### PR DESCRIPTION
## Summary
**TL;DR:**
- Streams EPUB grayscale planes in 80-row bands instead of requiring a full-frame BW backup.
- Reduces heap pressure during text anti-aliasing and image grayscale rendering.
- Adds SPI display locking and pooled bitmap scratch buffers to avoid repeated hot-path allocations.

**Goal:** Improve EPUB grayscale rendering stability and page-turn performance on ESP32-C3 devices with limited RAM and e-ink refresh constraints.

This feature came from community feedback comparing CPR-vCodex against CrossInk, where a Reddit comment specifically called out CrossInk feeling smoother and showing better grayscale behavior. The main pressure points were:
- grayscale rendering needing too much temporary memory,
- image-heavy pages feeling slower or more fragile,
- repeated bitmap row allocations adding heap churn during rendering.

---

## Changes

### Tiled Grayscale Rendering

**1. Stream grayscale planes by strip** (`src/activities/reader/EpubReaderActivity.cpp`, `lib/GfxRenderer/GfxRenderer.cpp`, `lib/GfxRenderer/GfxRenderer.h`, `lib/hal/HalDisplay.cpp`, `lib/hal/HalDisplay.h`)
Adds an 80-row tiled grayscale path that writes LSB/MSB grayscale planes directly to the display controller. This avoids storing a full 48KB BW backup when the strip path is available.

**2. Preserve full-frame fallback** (`src/activities/reader/EpubReaderActivity.cpp`)
Keeps the previous full-frame grayscale path as a fallback when strip grayscale is unavailable or scratch allocation fails.

**3. Keep dark-mode image grayscale working** (`src/activities/reader/EpubReaderActivity.cpp`)
Allows the grayscale pass to run for dark-mode image pages while still keeping text anti-aliasing disabled in dark mode.

### Rendering Performance

**4. Cull off-strip text and image work** (`lib/GfxRenderer/GfxRenderer.cpp`, `lib/Epub/Epub/converters/DirectPixelWriter.h`)
Skips glyphs and image columns outside the active strip so tiled grayscale does not waste work rendering pixels that cannot be written.

**5. Reuse bitmap scratch buffers** (`lib/GfxRenderer/GfxRenderer.cpp`, `lib/GfxRenderer/GfxRenderer.h`)
Pools bitmap row scratch memory behind a mutex to avoid repeated malloc/free cycles in image render paths.

### Display Hardening

**6. Serialize SPI display operations** (`lib/hal/HalSpiBus.cpp`, `lib/hal/HalSpiBus.h`, `lib/hal/HalDisplay.cpp`)
Adds a small recursive SPI bus lock around display operations touched by grayscale streaming.

---

## File summary

| File | What changed |
|---|---|
| `src/activities/reader/EpubReaderActivity.cpp` | Adds tiled grayscale pass, fallback handling, timing logs, and dark-mode image grayscale preservation. |
| `lib/GfxRenderer/GfxRenderer.cpp` | Adds strip targeting, glyph culling, grayscale strip writes, and pooled bitmap scratch buffers. |
| `lib/GfxRenderer/GfxRenderer.h` | Declares strip render target APIs and bitmap scratch state. |
| `lib/Epub/Epub/converters/DirectPixelWriter.h` | Writes into strip scratch buffers and computes active image column ranges. |
| `lib/Epub/Epub/blocks/TextBlock.cpp` | Adjusts bionic bold prewarm recording after removing `recordStyle`. |
| `lib/GfxRenderer/FontCacheManager.cpp` | Removes `recordStyle` and avoids shrinking scan text capacity after each prewarm. |
| `lib/GfxRenderer/FontCacheManager.h` | Removes unused `recordStyle` declaration. |
| `lib/hal/HalDisplay.cpp` | Adds SPI locking and strip grayscale plane forwarding. |
| `lib/hal/HalDisplay.h` | Exposes strip grayscale support and write APIs. |
| `lib/hal/HalSpiBus.cpp` | Adds recursive SPI bus lock implementation. |
| `lib/hal/HalSpiBus.h` | Adds SPI bus lock declaration. |

---

## Testing performed

| Scenario | Result |
|---|---|
| Branch fast-forward against `origin/master` | ✅ |
| `git diff --check` | ✅ |
| PlatformIO default build | ✅ |
| On-device EPUB text anti-aliasing page turn | ✅ |
| On-device dark-mode image grayscale page | ✅ |
| On-device image-heavy EPUB page turns | ✅ |

*Note: Final build/upload and on-device validation were performed locally before PR creation.*

---

## Pending / Known limitations

### Device-only visual sensitivity
The strip path has been validated on device, but grayscale appearance can still vary by panel and refresh conditions. Review should pay attention to strip alignment, grayscale plane order, and image-heavy pages.

### Fallback still allocates full BW backup
If strip grayscale is unavailable or scratch allocation fails, the reader intentionally falls back to the previous full-frame path, which can still require the larger BW backup allocation.

---

### AI Usage
Did you use AI tools to help write this code? **YES**