### PR TITLE
fix: OTA HTTPS failures when a populated .crosspoint folder leaves too little heap (bug #128)

### DIFF
--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -7,12 +7,12 @@
 #include <WiFi.h>
 
 #include "MappedInputManager.h"
-#include "ReadingStatsStore.h"
 #include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "network/OtaUpdater.h"
+#include "util/NetworkMemory.h"
 
 namespace {
 std::string formatByteSizeCompact(const size_t bytes) {
@@ -46,6 +46,8 @@ std::string buildNewVersionLine(const OtaUpdater& updater) {
 
 void OtaUpdateActivity::checkForUpdateNow() {
   LOG_DBG("OTA", "WiFi connected, checking for update");
+
+  NetworkMemory::prepareBeforeNetwork(renderer, "OTA", "pre-check");
 
   {
     RenderLock lock(*this);
@@ -100,7 +102,7 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
 void OtaUpdateActivity::onEnter() {
   Activity::onEnter();
 
-  READING_STATS.releaseMemoryForNetwork();
+  NetworkMemory::prepareBeforeNetwork(renderer, "OTA", "enter");
 
   // Turn on WiFi immediately
   LOG_DBG("OTA", "Turning on WiFi...");
@@ -209,6 +211,7 @@ void OtaUpdateActivity::loop() {
         lastUpdaterPercentage = UNINITIALIZED_PERCENTAGE;
       }
       requestUpdateAndWait();
+      NetworkMemory::prepareBeforeNetwork(renderer, "OTA", "pre-install");
       const auto res = updater.installUpdate(
           [](void* ctx) {
             // immediate=true notifies the render task directly. The default deferred path only


### PR DESCRIPTION


## Summary

**What is the goal of this PR?**
- This commit fixes bug #128, where OTA updates had stopped working on my X3 due to lack of available heap space

**What changes are included?**
* Use NetworkMemory::prepareBeforeNetwork in OtaUpdateActivity before the update check and firmware download so font caches and reading stats are released, freeing enough contiguous RAM for TLS after WiFi comes up.


## Additional Context

I added some temporary debug logging to diagnose what was actually going on. Here's that logging, pre-fix:
```
[000001] OTA: activity: onEnter
[000002] OTA: sd[crosspoint-dir]: path=/.crosspoint exists=1 readable=1 size=0
[000003] OTA: sd[reading_stats]: path=/.crosspoint/reading_stats.json exists=1 readable=1 size=16938
[000004] OTA: sd[ota-cache]: path=/.crosspoint/ota-update.bin exists=0 readable=0 size=0
[000005] OTA: sd[boot-events]: path=/.crosspoint/cpr-vcodex-logs/boot_events.log exists=1 readable=1 size=550
[000006] OTA: heap[activity-enter-before-stats-release]: free=110976 contig=81908 min_free=78
[000007] OTA: wifi[activity-enter]: status=254 rssi=0
[000008] OTA: stats release ok
[000009] OTA: heap[activity-enter-after-stats-release]: free=118944 contig=81908 min_free=787
[000010] OTA: activity: checkForUpdateNow
[000011] OTA: wifi[activity-check]: status=3 rssi=-57
[000012] OTA: heap[activity-check]: free=62532 contig=57332 min_free=56408
[000013] OTA: checkForUpdate begin
[000014] OTA: heap[check-start]: free=62540 contig=57332 min_free=56408
[000015] OTA: wifi[check-start]: status=3 rssi=-57
[000016] OTA: sd[crosspoint-dir]: path=/.crosspoint exists=1 readable=1 size=0
[000017] OTA: sd[reading_stats]: path=/.crosspoint/reading_stats.json exists=1 readable=1 size=16938
[000018] OTA: sd[ota-cache]: path=/.crosspoint/ota-update.bin exists=0 readable=0 size=0
[000019] OTA: sd[boot-events]: path=/.crosspoint/cpr-vcodex-logs/boot_events.log exists=1 readable=1 size=1531
[000020] OTA: heap[stream-request-start]: free=62540 contig=57332 min_free=56408
[000021] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000022] OTA: heap[stream-request-start]: free=61964 contig=49140 min_free=644
[000023] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000024] OTA: checkForUpdate failed
[000025] OTA: activity: check failed
[000026] OTA: activity: checkForUpdateNow
[000027] OTA: wifi[activity-check]: status=3 rssi=-57
[000028] OTA: heap[activity-check]: free=61992 contig=49140 min_free=144
[000029] OTA: checkForUpdate begin
[000030] OTA: heap[check-start]: free=61992 contig=49140 min_free=144
[000031] OTA: wifi[check-start]: status=3 rssi=-56
[000032] OTA: sd[crosspoint-dir]: path=/.crosspoint exists=1 readable=1 size=0
[000033] OTA: sd[reading_stats]: path=/.crosspoint/reading_stats.json exists=1 readable=1 size=16938
[000034] OTA: sd[ota-cache]: path=/.crosspoint/ota-update.bin exists=0 readable=0 size=0
[000035] OTA: sd[boot-events]: path=/.crosspoint/cpr-vcodex-logs/boot_events.log exists=1 readable=1 size=2615
[000036] OTA: heap[stream-request-start]: free=61992 contig=49140 min_free=144
[000037] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000038] OTA: heap[stream-request-start]: free=61960 contig=49140 min_free=144
[000039] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000040] OTA: checkForUpdate failed
[000041] OTA: activity: check failed
[000042] OTA: activity: onEnter
[000043] OTA: sd[crosspoint-dir]: path=/.crosspoint exists=1 readable=1 size=0
[000044] OTA: sd[reading_stats]: path=/.crosspoint/reading_stats.json exists=1 readable=1 size=16938
[000045] OTA: sd[ota-cache]: path=/.crosspoint/ota-update.bin exists=0 readable=0 size=0
[000046] OTA: sd[boot-events]: path=/.crosspoint/cpr-vcodex-logs/boot_events.log exists=1 readable=1 size=3404
[000047] OTA: heap[activity-enter-before-stats-release]: free=110976 contig=81908 min_free=78
[000048] OTA: wifi[activity-enter]: status=254 rssi=0
[000049] OTA: stats release ok
[000050] OTA: heap[activity-enter-after-stats-release]: free=118944 contig=81908 min_free=787
[000051] OTA: activity: checkForUpdateNow
[000052] OTA: wifi[activity-check]: status=3 rssi=-62
[000053] OTA: heap[activity-check]: free=62360 contig=57332 min_free=56568
[000054] OTA: checkForUpdate begin
[000055] OTA: heap[check-start]: free=62360 contig=57332 min_free=56568
[000056] OTA: wifi[check-start]: status=3 rssi=-55
[000057] OTA: sd[crosspoint-dir]: path=/.crosspoint exists=1 readable=1 size=0
[000058] OTA: sd[reading_stats]: path=/.crosspoint/reading_stats.json exists=1 readable=1 size=16938
[000059] OTA: sd[ota-cache]: path=/.crosspoint/ota-update.bin exists=0 readable=0 size=0
[000060] OTA: sd[boot-events]: path=/.crosspoint/cpr-vcodex-logs/boot_events.log exists=1 readable=1 size=4386
[000061] OTA: heap[stream-request-start]: free=62356 contig=57332 min_free=56568
[000062] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000063] OTA: heap[stream-request-start]: free=61564 contig=51188 min_free=296
[000064] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000065] OTA: checkForUpdate failed
[000066] OTA: activity: check failed
[000067] OTA: activity: checkForUpdateNow
[000068] OTA: wifi[activity-check]: status=3 rssi=-55
[000069] OTA: heap[activity-check]: free=62024 contig=51188 min_free=124
[000070] OTA: checkForUpdate begin
[000071] OTA: heap[check-start]: free=62024 contig=51188 min_free=124
[000072] OTA: wifi[check-start]: status=3 rssi=-56
[000073] OTA: sd[crosspoint-dir]: path=/.crosspoint exists=1 readable=1 size=0
[000074] OTA: sd[reading_stats]: path=/.crosspoint/reading_stats.json exists=1 readable=1 size=16938
[000075] OTA: sd[ota-cache]: path=/.crosspoint/ota-update.bin exists=0 readable=0 size=0
[000076] OTA: sd[boot-events]: path=/.crosspoint/cpr-vcodex-logs/boot_events.log exists=1 readable=1 size=5470
[000077] OTA: heap[stream-request-start]: free=62024 contig=51188 min_free=124
[000078] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000079] OTA: heap[stream-request-start]: free=61984 contig=51188 min_free=124
[000080] OTA: stream response: err=ESP_ERR_HTTP_CONNECT status=0 bytes=0
[000081] OTA: checkForUpdate failed
[000082] OTA: activity: check failed
```

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ 

While this is a pretty minimal change fix that I reviewed, the actual change was implemented by AI, but it seems completely reasonable and I have tested that this fix works by applying it to 1.3.0.29, which enabled me to upgrade to the official 1.3.0.30
