### PR TITLE
fix: improve sleep screen performance & fix sleep screen blank on Sleep Screen Cover Mode

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cassert>
 #include <climits>
+#include <cstring>
 #include <memory>
 #include <new>
 
@@ -1206,6 +1207,7 @@ bool SleepGreyStripBatch::appendStrip(const int yStart, const int numRows, const
   auto lsbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
   auto msbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
   if (!lsbCopy || !msbCopy) {
+    LOG_ERR("GFX", "OOM: sleep grey strip batch (%zu bytes x2)", stripBytes);
     return false;
   }
 
@@ -1215,7 +1217,7 @@ bool SleepGreyStripBatch::appendStrip(const int yStart, const int numRows, const
   return true;
 }
 
-void SleepGreyStripBatch::flush(const GfxRenderer& renderer) const {
+void SleepGreyStripBatch::flushToDisplay(const GfxRenderer& renderer) const {
   for (const Strip& strip : strips_) {
     renderer.writeGrayscalePlaneStrip(true, strip.lsb.get(), strip.yStart, strip.numRows);
     renderer.writeGrayscalePlaneStrip(false, strip.msb.get(), strip.yStart, strip.numRows);
@@ -1224,7 +1226,7 @@ void SleepGreyStripBatch::flush(const GfxRenderer& renderer) const {
 
 bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x, const int y, const int maxWidth,
                                               const int maxHeight, const float cropX, const float cropY,
-                                              SleepGreyStripBatch& greyStrips) const {
+                                              ISleepGreyStripSink& stripSink) const {
   if (fontCacheManager_ && fontCacheManager_->isScanning()) {
     return false;
   }
@@ -1295,7 +1297,7 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
       return true;
     }
     const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
-    return greyStrips.appendStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip);
+    return stripSink.appendStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip);
   };
 
   const auto flushThroughStrip = [&](const int targetStripIdx) -> bool {

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1123,18 +1123,7 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
     return;
   }
 
-  for (int bmpY = 0; bmpY < (bitmap.getHeight() - cropPixY); bmpY++) {
-    // The BMP's (0, 0) is the bottom-left corner (if the height is positive, top-left if negative).
-    // Screen's (0, 0) is the top-left corner.
-    int screenY = -cropPixY + (bitmap.isTopDown() ? bmpY : bitmap.getHeight() - 1 - bmpY);
-    if (isScaled) {
-      screenY = std::floor(screenY * scale);
-    }
-    screenY += y;  // the offset should not be scaled
-    if (screenY >= getScreenHeight()) {
-      break;
-    }
-
+  for (int bmpY = 0; bmpY < bitmap.getHeight(); bmpY++) {
     if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
       LOG_ERR("GFX", "Failed to read row %d from bitmap", bmpY);
       free(outputRow);
@@ -1142,12 +1131,18 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
       return;
     }
 
-    if (screenY < 0) {
+    const int rowFromTop = bitmap.isTopDown() ? bmpY : (bitmap.getHeight() - 1 - bmpY);
+    const int cropRowEnd = bitmap.getHeight() - cropPixY;
+    if (rowFromTop < cropPixY || rowFromTop >= cropRowEnd) {
       continue;
     }
 
-    if (bmpY < cropPixY) {
-      // Skip the row if it's outside the crop area
+    int screenY = rowFromTop - cropPixY;
+    if (isScaled) {
+      screenY = std::floor(static_cast<float>(screenY) * scale);
+    }
+    screenY += y;  // the offset should not be scaled
+    if (screenY < 0 || screenY >= getScreenHeight()) {
       continue;
     }
 
@@ -1400,16 +1395,7 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
       }
     }
   } else {
-    for (int bmpY = 0; bmpY < (bitmap.getHeight() - cropPixY); bmpY++) {
-      int screenY = -cropPixY + (bitmap.isTopDown() ? bmpY : bitmap.getHeight() - 1 - bmpY);
-      if (isScaled) {
-        screenY = std::floor(screenY * scale);
-      }
-      screenY += y;
-      if (screenY >= getScreenHeight()) {
-        break;
-      }
-
+    for (int bmpY = 0; bmpY < bitmap.getHeight(); bmpY++) {
       if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
         LOG_ERR("GFX", "Failed to read row %d from sleep greyscale bitmap", bmpY);
         free(outputRow);
@@ -1417,7 +1403,18 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
         return false;
       }
 
-      if (screenY < 0 || bmpY < cropPixY) {
+      const int rowFromTop = bitmap.isTopDown() ? bmpY : (bitmap.getHeight() - 1 - bmpY);
+      const int cropRowEnd = bitmap.getHeight() - cropPixY;
+      if (rowFromTop < cropPixY || rowFromTop >= cropRowEnd) {
+        continue;
+      }
+
+      int screenY = rowFromTop - cropPixY;
+      if (isScaled) {
+        screenY = std::floor(static_cast<float>(screenY) * scale);
+      }
+      screenY += y;
+      if (screenY < 0 || screenY >= getScreenHeight()) {
         continue;
       }
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1199,6 +1199,26 @@ bool SleepGreyStripBatch::appendStrip(const int yStart, const int numRows, const
     return false;
   }
 
+  for (Strip& existing : strips_) {
+    if (existing.yStart == yStart) {
+      if (existing.bytes < stripBytes) {
+        auto lsbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
+        auto msbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
+        if (!lsbCopy || !msbCopy) {
+          LOG_ERR("GFX", "OOM: sleep grey strip batch resize (%zu bytes x2)", stripBytes);
+          return false;
+        }
+        existing.lsb = std::move(lsbCopy);
+        existing.msb = std::move(msbCopy);
+        existing.bytes = stripBytes;
+      }
+      existing.numRows = numRows;
+      memcpy(existing.lsb.get(), lsb, stripBytes);
+      memcpy(existing.msb.get(), msb, stripBytes);
+      return true;
+    }
+  }
+
   auto lsbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
   auto msbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
   if (!lsbCopy || !msbCopy) {
@@ -1210,6 +1230,21 @@ bool SleepGreyStripBatch::appendStrip(const int yStart, const int numRows, const
   memcpy(msbCopy.get(), msb, stripBytes);
   strips_.push_back(Strip{yStart, numRows, stripBytes, std::move(lsbCopy), std::move(msbCopy)});
   return true;
+}
+
+bool SleepGreyStripBatch::loadStrip(const int yStart, const int numRows, const size_t stripBytes, uint8_t* lsb,
+                                    uint8_t* msb) const {
+  if (numRows <= 0 || stripBytes == 0 || lsb == nullptr || msb == nullptr) {
+    return false;
+  }
+  for (const Strip& existing : strips_) {
+    if (existing.yStart == yStart && existing.bytes >= stripBytes && existing.numRows == numRows) {
+      memcpy(lsb, existing.lsb.get(), stripBytes);
+      memcpy(msb, existing.msb.get(), stripBytes);
+      return true;
+    }
+  }
+  return false;
 }
 
 void SleepGreyStripBatch::flushToDisplay(const GfxRenderer& renderer) const {
@@ -1278,9 +1313,31 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
     return false;
   }
 
-  int buildingStripIdx = 0;
+  int buildingStripIdx = -1;
   memset(lsbStrip, 0, stripBytes);
   memset(msbStrip, 0, stripBytes);
+  bool stripWritten[32] = {};
+  if (lastStripIdx >= static_cast<int>(sizeof(stripWritten))) {
+    LOG_ERR("GFX", "Sleep greyscale strip count exceeds tracking array");
+    free(outputRow);
+    free(rowBytes);
+    return false;
+  }
+
+  // Prefer full-plane accumulation so Portrait (phyY decreases as logical X increases)
+  // does not thrash SD with per-row strip reload. Falls back to random-access strips.
+  const size_t planeSize = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(displayHeight);
+  auto lsbPlane = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[planeSize]);
+  auto msbPlane = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[planeSize]);
+  bool usePlaneAccum = lsbPlane && msbPlane;
+  if (usePlaneAccum) {
+    memset(lsbPlane.get(), 0, planeSize);
+    memset(msbPlane.get(), 0, planeSize);
+  } else {
+    lsbPlane.reset();
+    msbPlane.reset();
+    LOG_DBG("GFX", "Sleep greyscale plane accum unavailable; using strip reload path");
+  }
 
   const auto flushStrip = [&](const int stripIdx) -> bool {
     if (stripIdx < 0 || stripIdx > lastStripIdx) {
@@ -1292,19 +1349,30 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
       return true;
     }
     const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
-    return stripSink.appendStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip);
+    if (!stripSink.appendStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip)) {
+      return false;
+    }
+    stripWritten[stripIdx] = true;
+    return true;
   };
 
-  const auto flushThroughStrip = [&](const int targetStripIdx) -> bool {
-    while (buildingStripIdx < targetStripIdx) {
-      if (!flushStrip(buildingStripIdx)) {
-        return false;
-      }
-      buildingStripIdx++;
-      if (buildingStripIdx <= lastStripIdx) {
-        memset(lsbStrip, 0, stripBytes);
-        memset(msbStrip, 0, stripBytes);
-      }
+  const auto switchToStrip = [&](const int targetStripIdx) -> bool {
+    if (targetStripIdx < 0 || targetStripIdx > lastStripIdx) {
+      return true;
+    }
+    if (buildingStripIdx == targetStripIdx) {
+      return true;
+    }
+    if (buildingStripIdx >= 0 && !flushStrip(buildingStripIdx)) {
+      return false;
+    }
+    buildingStripIdx = targetStripIdx;
+    const int yStart = targetStripIdx * STRIP_ROWS;
+    const int rows = std::min(STRIP_ROWS, displayHeight - yStart);
+    const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
+    if (!stripSink.loadStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip)) {
+      memset(lsbStrip, 0, stripBytes);
+      memset(msbStrip, 0, stripBytes);
     }
     return true;
   };
@@ -1323,8 +1391,21 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
       return true;
     }
 
+    if (usePlaneAccum) {
+      const uint32_t byteIndex =
+          static_cast<uint32_t>(phyY) * panelWidthBytes + static_cast<uint32_t>(phyX / 8);
+      const uint8_t bitPosition = static_cast<uint8_t>(7 - (phyX % 8));
+      if (val == 1) {
+        lsbPlane[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
+      }
+      if (val == 1 || val == 2) {
+        msbPlane[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
+      }
+      return true;
+    }
+
     const int stripIdx = phyY / STRIP_ROWS;
-    if (!flushThroughStrip(stripIdx)) {
+    if (!switchToStrip(stripIdx)) {
       return false;
     }
     const int localRow = phyY - buildingStripIdx * STRIP_ROWS;
@@ -1441,16 +1522,38 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
     }
   }
 
-  while (buildingStripIdx <= lastStripIdx) {
-    if (!flushStrip(buildingStripIdx)) {
+  if (usePlaneAccum) {
+    for (int stripIdx = 0; stripIdx <= lastStripIdx; stripIdx++) {
+      const int yStart = stripIdx * STRIP_ROWS;
+      const int rows = std::min(STRIP_ROWS, displayHeight - yStart);
+      if (rows <= 0) {
+        continue;
+      }
+      const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
+      const size_t offset = static_cast<size_t>(yStart) * static_cast<size_t>(displayWidthBytes);
+      if (!stripSink.appendStrip(yStart, rows, activeStripBytes, lsbPlane.get() + offset, msbPlane.get() + offset)) {
+        free(outputRow);
+        free(rowBytes);
+        return false;
+      }
+    }
+  } else {
+    if (buildingStripIdx >= 0 && !flushStrip(buildingStripIdx)) {
       free(outputRow);
       free(rowBytes);
       return false;
     }
-    buildingStripIdx++;
-    if (buildingStripIdx <= lastStripIdx) {
+    for (int stripIdx = 0; stripIdx <= lastStripIdx; stripIdx++) {
+      if (stripWritten[stripIdx]) {
+        continue;
+      }
       memset(lsbStrip, 0, stripBytes);
       memset(msbStrip, 0, stripBytes);
+      if (!flushStrip(stripIdx)) {
+        free(outputRow);
+        free(rowBytes);
+        return false;
+      }
     }
   }
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -9,6 +9,8 @@
 #include <algorithm>
 #include <cassert>
 #include <climits>
+#include <memory>
+#include <new>
 
 #include "FontCacheManager.h"
 
@@ -1181,6 +1183,229 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
 
   free(outputRow);
   free(rowBytes);
+}
+
+namespace {
+  void setPlaneStripPixel(uint8_t* strip, const uint32_t widthBytes, const int localRow, const int phyX,
+                          const bool markBlack) {
+    if (localRow < 0) {
+      return;
+    }
+    const uint32_t byteIndex = static_cast<uint32_t>(localRow) * widthBytes + static_cast<uint32_t>(phyX / 8);
+    const uint8_t bitPosition = static_cast<uint8_t>(7 - (phyX % 8));
+    if (markBlack) {
+      strip[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
+    }
+  }
+}
+
+bool SleepGreyStripBatch::appendStrip(const int yStart, const int numRows, const size_t stripBytes, const uint8_t* lsb,
+                                      const uint8_t* msb) {
+  if (numRows <= 0 || stripBytes == 0 || lsb == nullptr || msb == nullptr) {
+    return false;
+  }
+
+  auto lsbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
+  auto msbCopy = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
+  if (!lsbCopy || !msbCopy) {
+    return false;
+  }
+
+  memcpy(lsbCopy.get(), lsb, stripBytes);
+  memcpy(msbCopy.get(), msb, stripBytes);
+  strips_.push_back(Strip{yStart, numRows, stripBytes, std::move(lsbCopy), std::move(msbCopy)});
+  return true;
+}
+
+void SleepGreyStripBatch::flush(const GfxRenderer& renderer) const {
+  for (const Strip& strip : strips_) {
+    renderer.writeGrayscalePlaneStrip(true, strip.lsb.get(), strip.yStart, strip.numRows);
+    renderer.writeGrayscalePlaneStrip(false, strip.msb.get(), strip.yStart, strip.numRows);
+  }
+}
+
+bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x, const int y, const int maxWidth,
+                                              const int maxHeight, const float cropX, const float cropY,
+                                              SleepGreyStripBatch& greyStrips) const {
+  if (fontCacheManager_ && fontCacheManager_->isScanning()) {
+    return false;
+  }
+  if (bitmap.is1Bit() || !bitmap.hasGreyscale() || !supportsStripGrayscale()) {
+    return false;
+  }
+
+  constexpr int STRIP_ROWS = 80;
+  const int displayHeight = static_cast<int>(panelHeight);
+  const int displayWidthBytes = static_cast<int>(panelWidthBytes);
+  const size_t stripBytes = static_cast<size_t>(displayWidthBytes) * STRIP_ROWS;
+  const int lastStripIdx = (displayHeight - 1) / STRIP_ROWS;
+
+  auto scratch = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes * 2]);
+  if (!scratch) {
+    LOG_ERR("GFX", "OOM: sleep greyscale strip scratch (%zu bytes)", stripBytes * 2);
+    return false;
+  }
+
+  uint8_t* lsbStrip = scratch.get();
+  uint8_t* msbStrip = scratch.get() + stripBytes;
+
+  float scale = 1.0f;
+  bool isScaled = false;
+  const int cropPixX = std::floor(bitmap.getWidth() * cropX / 2.0f);
+  const int cropPixY = std::floor(bitmap.getHeight() * cropY / 2.0f);
+
+  const float croppedWidth = (1.0f - cropX) * static_cast<float>(bitmap.getWidth());
+  const float croppedHeight = (1.0f - cropY) * static_cast<float>(bitmap.getHeight());
+  bool hasTargetBounds = false;
+  float fitScale = 1.0f;
+
+  if (maxWidth > 0 && croppedWidth > 0.0f) {
+    fitScale = static_cast<float>(maxWidth) / croppedWidth;
+    hasTargetBounds = true;
+  }
+  if (maxHeight > 0 && croppedHeight > 0.0f) {
+    const float heightScale = static_cast<float>(maxHeight) / croppedHeight;
+    fitScale = hasTargetBounds ? std::min(fitScale, heightScale) : heightScale;
+    hasTargetBounds = true;
+  }
+  if (hasTargetBounds && fitScale < 1.0f) {
+    scale = fitScale;
+    isScaled = true;
+  }
+
+  const int outputRowSize = (bitmap.getWidth() + 3) / 4;
+  auto* outputRow = static_cast<uint8_t*>(malloc(outputRowSize));
+  auto* rowBytes = static_cast<uint8_t*>(malloc(bitmap.getRowBytes()));
+  if (!outputRow || !rowBytes) {
+    LOG_ERR("GFX", "!! Failed to allocate BMP row buffers for sleep greyscale");
+    free(outputRow);
+    free(rowBytes);
+    return false;
+  }
+
+  int buildingStripIdx = 0;
+  memset(lsbStrip, 0, stripBytes);
+  memset(msbStrip, 0, stripBytes);
+
+  const auto flushStrip = [&](const int stripIdx) -> bool {
+    if (stripIdx < 0 || stripIdx > lastStripIdx) {
+      return true;
+    }
+    const int yStart = stripIdx * STRIP_ROWS;
+    const int rows = std::min(STRIP_ROWS, displayHeight - yStart);
+    if (rows <= 0) {
+      return true;
+    }
+    const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
+    return greyStrips.appendStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip);
+  };
+
+  const auto flushThroughStrip = [&](const int targetStripIdx) -> bool {
+    while (buildingStripIdx < targetStripIdx) {
+      if (!flushStrip(buildingStripIdx)) {
+        return false;
+      }
+      buildingStripIdx++;
+      if (buildingStripIdx <= lastStripIdx) {
+        memset(lsbStrip, 0, stripBytes);
+        memset(msbStrip, 0, stripBytes);
+      }
+    }
+    return true;
+  };
+
+  if (bitmap.rewindToData() != BmpReaderError::Ok) {
+    LOG_ERR("GFX", "Failed to rewind sleep greyscale bitmap");
+    free(outputRow);
+    free(rowBytes);
+    return false;
+  }
+
+  for (int bmpY = 0; bmpY < (bitmap.getHeight() - cropPixY); bmpY++) {
+    int screenY = -cropPixY + (bitmap.isTopDown() ? bmpY : bitmap.getHeight() - 1 - bmpY);
+    if (isScaled) {
+      screenY = std::floor(screenY * scale);
+    }
+    screenY += y;
+    if (screenY >= getScreenHeight()) {
+      break;
+    }
+
+    if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
+      LOG_ERR("GFX", "Failed to read row %d from sleep greyscale bitmap", bmpY);
+      free(outputRow);
+      free(rowBytes);
+      return false;
+    }
+
+    if (screenY < 0 || bmpY < cropPixY) {
+      continue;
+    }
+
+    for (int bmpX = cropPixX; bmpX < bitmap.getWidth() - cropPixX; bmpX++) {
+      int screenX = bmpX - cropPixX;
+      if (isScaled) {
+        screenX = std::floor(screenX * scale);
+      }
+      screenX += x;
+      if (screenX >= getScreenWidth()) {
+        break;
+      }
+      if (screenX < 0) {
+        continue;
+      }
+
+      const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
+
+      if (darkMode) {
+        drawPixelRaw(screenX, screenY, val < 3);
+      } else if (val < 3) {
+        drawPixelRaw(screenX, screenY, true);
+      }
+
+      int phyX = 0;
+      int phyY = 0;
+      rotateCoordinates(orientation, screenX, screenY, &phyX, &phyY, panelWidth, panelHeight);
+      if (phyX < 0 || phyX >= static_cast<int>(panelWidth) || phyY < 0 || phyY >= displayHeight) {
+        continue;
+      }
+
+      const int stripIdx = phyY / STRIP_ROWS;
+      if (!flushThroughStrip(stripIdx)) {
+        free(outputRow);
+        free(rowBytes);
+        return false;
+      }
+      const int localRow = phyY - buildingStripIdx * STRIP_ROWS;
+      if (localRow < 0 || localRow >= STRIP_ROWS) {
+        continue;
+      }
+
+      if (val == 1) {
+        setPlaneStripPixel(lsbStrip, panelWidthBytes, localRow, phyX, true);
+      }
+      if (val == 1 || val == 2) {
+        setPlaneStripPixel(msbStrip, panelWidthBytes, localRow, phyX, true);
+      }
+    }
+  }
+
+  while (buildingStripIdx <= lastStripIdx) {
+    if (!flushStrip(buildingStripIdx)) {
+      free(outputRow);
+      free(rowBytes);
+      return false;
+    }
+    buildingStripIdx++;
+    if (buildingStripIdx <= lastStripIdx) {
+      memset(lsbStrip, 0, stripBytes);
+      memset(msbStrip, 0, stripBytes);
+    }
+  }
+
+  free(outputRow);
+  free(rowBytes);
+  return true;
 }
 
 void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y, const int maxWidth,

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -15,24 +15,22 @@
 #include "FontCacheManager.h"
 
 namespace {
-
-std::vector<uint8_t> invertMonochromeBitmap(const uint8_t* bitmap, size_t size) {
-  std::vector<uint8_t> inverted(size);
-  for (size_t i = 0; i < size; ++i) {
-    inverted[i] = static_cast<uint8_t>(~bitmap[i]);
+  std::vector<uint8_t> invertMonochromeBitmap(const uint8_t* bitmap, size_t size) {
+    std::vector<uint8_t> inverted(size);
+    for (size_t i = 0; i < size; ++i) {
+      inverted[i] = static_cast<uint8_t>(~bitmap[i]);
+    }
+    return inverted;
   }
-  return inverted;
-}
 
-/**
- * Resolves the requested style to the best available style in the given SD card font.
- * Falls back gracefully when the font lacks the requested variant.
- */
-uint8_t resolveSdCardStyle(const SdCardFont& font, const EpdFontFamily::Style style) {
-  return font.resolveStyle(static_cast<uint8_t>(style));
+  /**
+  * Resolves the requested style to the best available style in the given SD card font.
+  * Falls back gracefully when the font lacks the requested variant.
+  */
+  uint8_t resolveSdCardStyle(const SdCardFont& font, const EpdFontFamily::Style style) {
+    return font.resolveStyle(static_cast<uint8_t>(style));
+  }
 }
-
-}  // namespace
 
 const uint8_t* GfxRenderer::getGlyphBitmap(const EpdFontData* fontData, const EpdGlyph* glyph) const {
   if (fontData->groups != nullptr) {
@@ -1314,6 +1312,38 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
     return true;
   };
 
+  const auto emitSleepGreyPixel = [&](const int screenX, const int screenY, const uint8_t val) -> bool {
+    if (darkMode) {
+      drawPixelRaw(screenX, screenY, val < 3);
+    } else if (val < 3) {
+      drawPixelRaw(screenX, screenY, true);
+    }
+
+    int phyX = 0;
+    int phyY = 0;
+    rotateCoordinates(orientation, screenX, screenY, &phyX, &phyY, panelWidth, panelHeight);
+    if (phyX < 0 || phyX >= static_cast<int>(panelWidth) || phyY < 0 || phyY >= displayHeight) {
+      return true;
+    }
+
+    const int stripIdx = phyY / STRIP_ROWS;
+    if (!flushThroughStrip(stripIdx)) {
+      return false;
+    }
+    const int localRow = phyY - buildingStripIdx * STRIP_ROWS;
+    if (localRow < 0 || localRow >= STRIP_ROWS) {
+      return true;
+    }
+
+    if (val == 1) {
+      setPlaneStripPixel(lsbStrip, panelWidthBytes, localRow, phyX, true);
+    }
+    if (val == 1 || val == 2) {
+      setPlaneStripPixel(msbStrip, panelWidthBytes, localRow, phyX, true);
+    }
+    return true;
+  };
+
   if (bitmap.rewindToData() != BmpReaderError::Ok) {
     LOG_ERR("GFX", "Failed to rewind sleep greyscale bitmap");
     free(outputRow);
@@ -1321,71 +1351,93 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
     return false;
   }
 
-  for (int bmpY = 0; bmpY < (bitmap.getHeight() - cropPixY); bmpY++) {
-    int screenY = -cropPixY + (bitmap.isTopDown() ? bmpY : bitmap.getHeight() - 1 - bmpY);
-    if (isScaled) {
-      screenY = std::floor(screenY * scale);
-    }
-    screenY += y;
-    if (screenY >= getScreenHeight()) {
-      break;
-    }
-
-    if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
-      LOG_ERR("GFX", "Failed to read row %d from sleep greyscale bitmap", bmpY);
+  if (isScaled && bitmap.isTopDown()) {
+    const int croppedBmpW = bitmap.getWidth() - 2 * cropPixX;
+    const int croppedBmpH = bitmap.getHeight() - cropPixY;
+    if (croppedBmpW <= 0 || croppedBmpH <= 0) {
       free(outputRow);
       free(rowBytes);
       return false;
     }
 
-    if (screenY < 0 || bmpY < cropPixY) {
-      continue;
-    }
-
-    for (int bmpX = cropPixX; bmpX < bitmap.getWidth() - cropPixX; bmpX++) {
-      int screenX = bmpX - cropPixX;
-      if (isScaled) {
-        screenX = std::floor(screenX * scale);
-      }
-      screenX += x;
-      if (screenX >= getScreenWidth()) {
+    const int maxDrawRow = std::min(getScreenHeight() - y, static_cast<int>(std::floor(croppedBmpH * scale)) + 1);
+    int nextFileRow = 0;
+    for (int outRow = 0; outRow < maxDrawRow; outRow++) {
+      const int screenY = y + outRow;
+      const int srcCroppedRow = static_cast<int>(std::floor(static_cast<float>(outRow) / scale));
+      if (srcCroppedRow >= croppedBmpH) {
         break;
       }
-      if (screenX < 0) {
-        continue;
+
+      const int fileRow = cropPixY + srcCroppedRow;
+      while (nextFileRow <= fileRow) {
+        if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
+          LOG_ERR("GFX", "Failed to read row %d from sleep greyscale bitmap", nextFileRow);
+          free(outputRow);
+          free(rowBytes);
+          return false;
+        }
+        nextFileRow++;
       }
 
-      const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
+      const int maxDrawCol = std::min(getScreenWidth() - x, static_cast<int>(std::floor(croppedBmpW * scale)) + 1);
+      for (int outCol = 0; outCol < maxDrawCol; outCol++) {
+        const int screenX = x + outCol;
+        const int srcCroppedCol = static_cast<int>(std::floor(static_cast<float>(outCol) / scale));
+        if (srcCroppedCol >= croppedBmpW) {
+          break;
+        }
 
-      if (darkMode) {
-        drawPixelRaw(screenX, screenY, val < 3);
-      } else if (val < 3) {
-        drawPixelRaw(screenX, screenY, true);
+        const int bmpX = cropPixX + srcCroppedCol;
+        const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
+        if (!emitSleepGreyPixel(screenX, screenY, val)) {
+          free(outputRow);
+          free(rowBytes);
+          return false;
+        }
+      }
+    }
+  } else {
+    for (int bmpY = 0; bmpY < (bitmap.getHeight() - cropPixY); bmpY++) {
+      int screenY = -cropPixY + (bitmap.isTopDown() ? bmpY : bitmap.getHeight() - 1 - bmpY);
+      if (isScaled) {
+        screenY = std::floor(screenY * scale);
+      }
+      screenY += y;
+      if (screenY >= getScreenHeight()) {
+        break;
       }
 
-      int phyX = 0;
-      int phyY = 0;
-      rotateCoordinates(orientation, screenX, screenY, &phyX, &phyY, panelWidth, panelHeight);
-      if (phyX < 0 || phyX >= static_cast<int>(panelWidth) || phyY < 0 || phyY >= displayHeight) {
-        continue;
-      }
-
-      const int stripIdx = phyY / STRIP_ROWS;
-      if (!flushThroughStrip(stripIdx)) {
+      if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
+        LOG_ERR("GFX", "Failed to read row %d from sleep greyscale bitmap", bmpY);
         free(outputRow);
         free(rowBytes);
         return false;
       }
-      const int localRow = phyY - buildingStripIdx * STRIP_ROWS;
-      if (localRow < 0 || localRow >= STRIP_ROWS) {
+
+      if (screenY < 0 || bmpY < cropPixY) {
         continue;
       }
 
-      if (val == 1) {
-        setPlaneStripPixel(lsbStrip, panelWidthBytes, localRow, phyX, true);
-      }
-      if (val == 1 || val == 2) {
-        setPlaneStripPixel(msbStrip, panelWidthBytes, localRow, phyX, true);
+      for (int bmpX = cropPixX; bmpX < bitmap.getWidth() - cropPixX; bmpX++) {
+        int screenX = bmpX - cropPixX;
+        if (isScaled) {
+          screenX = std::floor(screenX * scale);
+        }
+        screenX += x;
+        if (screenX >= getScreenWidth()) {
+          break;
+        }
+        if (screenX < 0) {
+          continue;
+        }
+
+        const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
+        if (!emitSleepGreyPixel(screenX, screenY, val)) {
+          free(outputRow);
+          free(rowBytes);
+          return false;
+        }
       }
     }
   }

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1179,20 +1179,6 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
   free(rowBytes);
 }
 
-namespace {
-  void setPlaneStripPixel(uint8_t* strip, const uint32_t widthBytes, const int localRow, const int phyX,
-                          const bool markBlack) {
-    if (localRow < 0) {
-      return;
-    }
-    const uint32_t byteIndex = static_cast<uint32_t>(localRow) * widthBytes + static_cast<uint32_t>(phyX / 8);
-    const uint8_t bitPosition = static_cast<uint8_t>(7 - (phyX % 8));
-    if (markBlack) {
-      strip[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
-    }
-  }
-}
-
 bool SleepGreyStripBatch::appendStrip(const int yStart, const int numRows, const size_t stripBytes, const uint8_t* lsb,
                                       const uint8_t* msb) {
   if (numRows <= 0 || stripBytes == 0 || lsb == nullptr || msb == nullptr) {
@@ -1267,17 +1253,20 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
   constexpr int STRIP_ROWS = 80;
   const int displayHeight = static_cast<int>(panelHeight);
   const int displayWidthBytes = static_cast<int>(panelWidthBytes);
-  const size_t stripBytes = static_cast<size_t>(displayWidthBytes) * STRIP_ROWS;
   const int lastStripIdx = (displayHeight - 1) / STRIP_ROWS;
 
-  auto scratch = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes * 2]);
-  if (!scratch) {
-    LOG_ERR("GFX", "OOM: sleep greyscale strip scratch (%zu bytes)", stripBytes * 2);
+  // Full-plane accumulation is required for Portrait: phyY decreases as logical X
+  // increases, so streaming strips while decoding would thrash SD (minutes of seek
+  // reload). If ~2x panel RAM is unavailable, fail and let SleepActivity overlay.
+  const size_t planeSize = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(displayHeight);
+  auto planeStorage = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[planeSize * 2]);
+  if (!planeStorage) {
+    LOG_ERR("GFX", "OOM: sleep greyscale plane buffers (%zu bytes); falling back", planeSize * 2);
     return false;
   }
-
-  uint8_t* lsbStrip = scratch.get();
-  uint8_t* msbStrip = scratch.get() + stripBytes;
+  uint8_t* lsbPlane = planeStorage.get();
+  uint8_t* msbPlane = planeStorage.get() + planeSize;
+  memset(lsbPlane, 0, planeSize * 2);
 
   float scale = 1.0f;
   bool isScaled = false;
@@ -1313,71 +1302,7 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
     return false;
   }
 
-  int buildingStripIdx = -1;
-  memset(lsbStrip, 0, stripBytes);
-  memset(msbStrip, 0, stripBytes);
-  bool stripWritten[32] = {};
-  if (lastStripIdx >= static_cast<int>(sizeof(stripWritten))) {
-    LOG_ERR("GFX", "Sleep greyscale strip count exceeds tracking array");
-    free(outputRow);
-    free(rowBytes);
-    return false;
-  }
-
-  // Prefer full-plane accumulation so Portrait (phyY decreases as logical X increases)
-  // does not thrash SD with per-row strip reload. Falls back to random-access strips.
-  const size_t planeSize = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(displayHeight);
-  auto lsbPlane = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[planeSize]);
-  auto msbPlane = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[planeSize]);
-  bool usePlaneAccum = lsbPlane && msbPlane;
-  if (usePlaneAccum) {
-    memset(lsbPlane.get(), 0, planeSize);
-    memset(msbPlane.get(), 0, planeSize);
-  } else {
-    lsbPlane.reset();
-    msbPlane.reset();
-    LOG_DBG("GFX", "Sleep greyscale plane accum unavailable; using strip reload path");
-  }
-
-  const auto flushStrip = [&](const int stripIdx) -> bool {
-    if (stripIdx < 0 || stripIdx > lastStripIdx) {
-      return true;
-    }
-    const int yStart = stripIdx * STRIP_ROWS;
-    const int rows = std::min(STRIP_ROWS, displayHeight - yStart);
-    if (rows <= 0) {
-      return true;
-    }
-    const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
-    if (!stripSink.appendStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip)) {
-      return false;
-    }
-    stripWritten[stripIdx] = true;
-    return true;
-  };
-
-  const auto switchToStrip = [&](const int targetStripIdx) -> bool {
-    if (targetStripIdx < 0 || targetStripIdx > lastStripIdx) {
-      return true;
-    }
-    if (buildingStripIdx == targetStripIdx) {
-      return true;
-    }
-    if (buildingStripIdx >= 0 && !flushStrip(buildingStripIdx)) {
-      return false;
-    }
-    buildingStripIdx = targetStripIdx;
-    const int yStart = targetStripIdx * STRIP_ROWS;
-    const int rows = std::min(STRIP_ROWS, displayHeight - yStart);
-    const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
-    if (!stripSink.loadStrip(yStart, rows, activeStripBytes, lsbStrip, msbStrip)) {
-      memset(lsbStrip, 0, stripBytes);
-      memset(msbStrip, 0, stripBytes);
-    }
-    return true;
-  };
-
-  const auto emitSleepGreyPixel = [&](const int screenX, const int screenY, const uint8_t val) -> bool {
+  const auto emitSleepGreyPixel = [&](const int screenX, const int screenY, const uint8_t val) {
     if (darkMode) {
       drawPixelRaw(screenX, screenY, val < 3);
     } else if (val < 3) {
@@ -1388,38 +1313,18 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
     int phyY = 0;
     rotateCoordinates(orientation, screenX, screenY, &phyX, &phyY, panelWidth, panelHeight);
     if (phyX < 0 || phyX >= static_cast<int>(panelWidth) || phyY < 0 || phyY >= displayHeight) {
-      return true;
+      return;
     }
 
-    if (usePlaneAccum) {
-      const uint32_t byteIndex =
-          static_cast<uint32_t>(phyY) * panelWidthBytes + static_cast<uint32_t>(phyX / 8);
-      const uint8_t bitPosition = static_cast<uint8_t>(7 - (phyX % 8));
-      if (val == 1) {
-        lsbPlane[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
-      }
-      if (val == 1 || val == 2) {
-        msbPlane[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
-      }
-      return true;
-    }
-
-    const int stripIdx = phyY / STRIP_ROWS;
-    if (!switchToStrip(stripIdx)) {
-      return false;
-    }
-    const int localRow = phyY - buildingStripIdx * STRIP_ROWS;
-    if (localRow < 0 || localRow >= STRIP_ROWS) {
-      return true;
-    }
-
+    const uint32_t byteIndex =
+        static_cast<uint32_t>(phyY) * panelWidthBytes + static_cast<uint32_t>(phyX / 8);
+    const uint8_t bitPosition = static_cast<uint8_t>(7 - (phyX % 8));
     if (val == 1) {
-      setPlaneStripPixel(lsbStrip, panelWidthBytes, localRow, phyX, true);
+      lsbPlane[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
     }
     if (val == 1 || val == 2) {
-      setPlaneStripPixel(msbStrip, panelWidthBytes, localRow, phyX, true);
+      msbPlane[byteIndex] |= static_cast<uint8_t>(1 << bitPosition);
     }
-    return true;
   };
 
   if (bitmap.rewindToData() != BmpReaderError::Ok) {
@@ -1468,11 +1373,7 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
 
         const int bmpX = cropPixX + srcCroppedCol;
         const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
-        if (!emitSleepGreyPixel(screenX, screenY, val)) {
-          free(outputRow);
-          free(rowBytes);
-          return false;
-        }
+        emitSleepGreyPixel(screenX, screenY, val);
       }
     }
   } else {
@@ -1513,47 +1414,23 @@ bool GfxRenderer::drawGreyscaleBitmapForSleep(const Bitmap& bitmap, const int x,
         }
 
         const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
-        if (!emitSleepGreyPixel(screenX, screenY, val)) {
-          free(outputRow);
-          free(rowBytes);
-          return false;
-        }
+        emitSleepGreyPixel(screenX, screenY, val);
       }
     }
   }
 
-  if (usePlaneAccum) {
-    for (int stripIdx = 0; stripIdx <= lastStripIdx; stripIdx++) {
-      const int yStart = stripIdx * STRIP_ROWS;
-      const int rows = std::min(STRIP_ROWS, displayHeight - yStart);
-      if (rows <= 0) {
-        continue;
-      }
-      const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
-      const size_t offset = static_cast<size_t>(yStart) * static_cast<size_t>(displayWidthBytes);
-      if (!stripSink.appendStrip(yStart, rows, activeStripBytes, lsbPlane.get() + offset, msbPlane.get() + offset)) {
-        free(outputRow);
-        free(rowBytes);
-        return false;
-      }
+  for (int stripIdx = 0; stripIdx <= lastStripIdx; stripIdx++) {
+    const int yStart = stripIdx * STRIP_ROWS;
+    const int rows = std::min(STRIP_ROWS, displayHeight - yStart);
+    if (rows <= 0) {
+      continue;
     }
-  } else {
-    if (buildingStripIdx >= 0 && !flushStrip(buildingStripIdx)) {
+    const size_t activeStripBytes = static_cast<size_t>(displayWidthBytes) * static_cast<size_t>(rows);
+    const size_t offset = static_cast<size_t>(yStart) * static_cast<size_t>(displayWidthBytes);
+    if (!stripSink.appendStrip(yStart, rows, activeStripBytes, lsbPlane + offset, msbPlane + offset)) {
       free(outputRow);
       free(rowBytes);
       return false;
-    }
-    for (int stripIdx = 0; stripIdx <= lastStripIdx; stripIdx++) {
-      if (stripWritten[stripIdx]) {
-        continue;
-      }
-      memset(lsbStrip, 0, stripBytes);
-      memset(msbStrip, 0, stripBytes);
-      if (!flushStrip(stripIdx)) {
-        free(outputRow);
-        free(rowBytes);
-        return false;
-      }
     }
   }
 

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -36,6 +36,7 @@ class SleepGreyStripBatch : public ISleepGreyStripSink {
   bool empty() const override { return strips_.empty(); }
 
   bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb) override;
+  bool loadStrip(int yStart, int numRows, size_t stripBytes, uint8_t* lsb, uint8_t* msb) const override;
 
   void flushToDisplay(const GfxRenderer& renderer) const override;
 

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -196,6 +196,7 @@ class GfxRenderer {
   void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0,
                   float cropY = 0) const;
   // One SD read pass: composes the BW framebuffer and records grey LSB/MSB strips in greyStrips.
+  // Downscales via output-driven nearest-neighbor sampling when the source exceeds the target.
   // Caller must displaySleepGrayscaleBase, greyStrips.flush(), then displayGrayBuffer.
   bool drawGreyscaleBitmapForSleep(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX,
                                    float cropY, SleepGreyStripBatch& greyStrips) const;

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -8,6 +8,8 @@ class SdCardFont;
 
 #include <cstring>
 #include <map>
+#include <memory>
+#include <new>
 #include <string>
 #include <vector>
 
@@ -23,6 +25,30 @@ enum Color : uint8_t {
   DarkGray = 0x0A,
   ExtraDarkGray = 0x0D,
   Black = 0x10
+};
+
+class GfxRenderer;
+
+// Deferred grey plane strips for sleep rendering. Populated during a single BMP read,
+// then flushed after displaySleepGrayscaleBase so stale UI grey state is not composited in.
+class SleepGreyStripBatch {
+ public:
+  bool empty() const { return strips_.empty(); }
+
+  bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb);
+
+  void flush(const GfxRenderer& renderer) const;
+
+ private:
+  struct Strip {
+    int yStart = 0;
+    int numRows = 0;
+    size_t bytes = 0;
+    std::unique_ptr<uint8_t[]> lsb;
+    std::unique_ptr<uint8_t[]> msb;
+  };
+
+  std::vector<Strip> strips_;
 };
 
 class GfxRenderer {
@@ -169,6 +195,10 @@ class GfxRenderer {
   void drawIconInverted(const uint8_t bitmap[], int x, int y, int width, int height) const;
   void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0,
                   float cropY = 0) const;
+  // One SD read pass: composes the BW framebuffer and records grey LSB/MSB strips in greyStrips.
+  // Caller must displaySleepGrayscaleBase, greyStrips.flush(), then displayGrayBuffer.
+  bool drawGreyscaleBitmapForSleep(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX,
+                                   float cropY, SleepGreyStripBatch& greyStrips) const;
   void drawBitmap1Bit(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight) const;
   void fillPolygon(const int* xPoints, const int* yPoints, int numPoints, bool state = true) const;
 

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -14,6 +14,7 @@ class SdCardFont;
 #include <vector>
 
 #include "Bitmap.h"
+#include "SleepGreyStripSink.h"
 
 // Color representation: uint8_t mapped to 4x4 Bayer matrix dithering levels
 // 0 = transparent, 1-16 = gray levels (white to black)
@@ -29,15 +30,14 @@ enum Color : uint8_t {
 
 class GfxRenderer;
 
-// Deferred grey plane strips for sleep rendering. Populated during a single BMP read,
-// then flushed after displaySleepGrayscaleBase so stale UI grey state is not composited in.
-class SleepGreyStripBatch {
+// In-memory grey strip batch. Used only when SD streaming is unavailable.
+class SleepGreyStripBatch : public ISleepGreyStripSink {
  public:
-  bool empty() const { return strips_.empty(); }
+  bool empty() const override { return strips_.empty(); }
 
-  bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb);
+  bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb) override;
 
-  void flush(const GfxRenderer& renderer) const;
+  void flushToDisplay(const GfxRenderer& renderer) const override;
 
  private:
   struct Strip {
@@ -195,11 +195,11 @@ class GfxRenderer {
   void drawIconInverted(const uint8_t bitmap[], int x, int y, int width, int height) const;
   void drawBitmap(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX = 0,
                   float cropY = 0) const;
-  // One SD read pass: composes the BW framebuffer and records grey LSB/MSB strips in greyStrips.
+  // One SD read pass: composes the BW framebuffer and records grey LSB/MSB strips in stripSink.
   // Downscales via output-driven nearest-neighbor sampling when the source exceeds the target.
-  // Caller must displaySleepGrayscaleBase, greyStrips.flush(), then displayGrayBuffer.
+  // Caller must displaySleepGrayscaleBase, stripSink.flushToDisplay(), then displayGrayBuffer.
   bool drawGreyscaleBitmapForSleep(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight, float cropX,
-                                   float cropY, SleepGreyStripBatch& greyStrips) const;
+                                   float cropY, ISleepGreyStripSink& stripSink) const;
   void drawBitmap1Bit(const Bitmap& bitmap, int x, int y, int maxWidth, int maxHeight) const;
   void fillPolygon(const int* xPoints, const int* yPoints, int numPoints, bool state = true) const;
 

--- a/lib/GfxRenderer/SleepGreyStripSink.h
+++ b/lib/GfxRenderer/SleepGreyStripSink.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+class GfxRenderer;
+
+// Receives grey LSB/MSB strips during a single-pass sleep BMP decode.
+class ISleepGreyStripSink {
+ public:
+  virtual ~ISleepGreyStripSink() = default;
+  virtual bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb) = 0;
+  virtual void flushToDisplay(const GfxRenderer& renderer) const = 0;
+  virtual bool empty() const = 0;
+};

--- a/lib/GfxRenderer/SleepGreyStripSink.h
+++ b/lib/GfxRenderer/SleepGreyStripSink.h
@@ -6,10 +6,14 @@
 class GfxRenderer;
 
 // Receives grey LSB/MSB strips during a single-pass sleep BMP decode.
+// Strips may be written in any physical-Y order (Portrait maps logical X -> phyY).
 class ISleepGreyStripSink {
  public:
   virtual ~ISleepGreyStripSink() = default;
   virtual bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb) = 0;
+  // Load a previously written strip back into the scratch buffers. Returns false if missing
+  // (caller should treat the strip as zeros).
+  virtual bool loadStrip(int yStart, int numRows, size_t stripBytes, uint8_t* lsb, uint8_t* msb) const = 0;
   virtual void flushToDisplay(const GfxRenderer& renderer) const = 0;
   virtual bool empty() const = 0;
 };

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -826,7 +825,12 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const std::str
   const bool hasGreyscale = bitmap.hasGreyscale() &&
                             SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 
-  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  SleepGreyStripBatch greyStrips;
+  const bool greyscaleOnce =
+      hasGreyscale && renderer.drawGreyscaleBitmapForSleep(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, greyStrips);
+  if (!greyscaleOnce) {
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  }
 
   if (SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
     renderer.invertScreen();
@@ -837,10 +841,17 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const std::str
   }
 
   if (hasGreyscale) {
-    renderSleepGrayscaleOverlay(renderer, [&]() {
-      bitmap.rewindToData();
-      renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
-    });
+    if (greyscaleOnce) {
+      displaySleepGrayscaleBase(renderer);
+      greyStrips.flush(renderer);
+      renderer.displayGrayBuffer();
+      renderer.setRenderMode(GfxRenderer::BW);
+    } else {
+      renderSleepGrayscaleOverlay(renderer, [&]() {
+        bitmap.rewindToData();
+        renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+      });
+    }
   } else {
     displaySleepBuffer(renderer);
   }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -89,18 +89,35 @@ bool tryDisplayCachedSleepScreen(const GfxRenderer& renderer, const std::string&
 }
 
 template <typename RenderFn>
-void renderSleepGrayscaleOverlay(GfxRenderer& renderer, RenderFn&& renderFn) {
+void renderSleepGrayscaleOverlay(GfxRenderer& renderer, RenderFn&& renderFn, const std::string& cacheSourcePath = {},
+                                 const uint32_t cacheSourceSize = 0) {
+  // BW plane is already drawn into the framebuffer by the caller.
+  bool cacheOk =
+      !cacheSourcePath.empty() && cacheSourceSize != 0 &&
+      SleepScreenCache::prepareGreyscaleSave(cacheSourcePath, cacheSourceSize);
+  if (cacheOk && !SleepScreenCache::saveFrameBufferPlane(renderer, cacheSourcePath, cacheSourceSize, ".raw")) {
+    LOG_ERR("SLP", "Failed to cache sleep BW plane");
+    cacheOk = false;
+  }
+
   displaySleepGrayscaleBase(renderer);
 
   renderer.clearScreen(0x00);
   renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
   renderFn();
   renderer.copyGrayscaleLsbBuffers();
+  if (cacheOk && !SleepScreenCache::saveFrameBufferPlane(renderer, cacheSourcePath, cacheSourceSize, ".lsb.raw")) {
+    LOG_ERR("SLP", "Failed to cache sleep LSB plane");
+    cacheOk = false;
+  }
 
   renderer.clearScreen(0x00);
   renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
   renderFn();
   renderer.copyGrayscaleMsbBuffers();
+  if (cacheOk && !SleepScreenCache::saveFrameBufferPlane(renderer, cacheSourcePath, cacheSourceSize, ".msb.raw")) {
+    LOG_ERR("SLP", "Failed to cache sleep MSB plane");
+  }
 
   renderer.displayGrayBuffer();
   renderer.setRenderMode(GfxRenderer::BW);
@@ -867,54 +884,29 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const std::str
   const bool hasGreyscale = bitmap.hasGreyscale() &&
                             SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 
-  SleepGreyStripBatch memoryStrips;
-  SleepGreyscaleStreamWriter streamWriter;
-  ISleepGreyStripSink* stripSink = nullptr;
-  if (hasGreyscale) {
-    if (!sourcePath.empty() &&
-        streamWriter.begin(sourcePath, sourceFileSize, display.getBufferSize(), renderer.getDisplayWidthBytes(),
-                           renderer.getDisplayHeight())) {
-      stripSink = &streamWriter;
-    } else if (sourcePath.empty()) {
-      stripSink = &memoryStrips;
-    }
-  }
-
-  const bool greyscaleOnce =
-      hasGreyscale && stripSink != nullptr &&
-      renderer.drawGreyscaleBitmapForSleep(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, *stripSink);
-  if (!greyscaleOnce) {
-    if (streamWriter.isActive()) {
-      streamWriter.abort();
-    }
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
-  }
+  // Always draw BW into the framebuffer first. Greyscale uses the overlay path
+  // (LSB/MSB passes) which stays within normal heap limits and can snapshot each
+  // plane into sleep_cache. The dual-plane stream encode needs ~104KB contiguous
+  // RAM and routinely OOMs on ESP32-C3, which aborted cache writes and forced a
+  // slow cold overlay on every sleep.
+  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
 
   if (SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
     renderer.invertScreen();
   }
 
-  if (!sourcePath.empty()) {
-    if (streamWriter.isActive() && greyscaleOnce) {
-      streamWriter.commitBw(renderer.getFrameBuffer(), display.getBufferSize());
-    } else if (canUseSleepCache(bitmap)) {
+  if (hasGreyscale) {
+    renderSleepGrayscaleOverlay(
+        renderer,
+        [&]() {
+          bitmap.rewindToData();
+          renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+        },
+        sourcePath, sourceFileSize);
+  } else {
+    if (!sourcePath.empty() && canUseSleepCache(bitmap)) {
       SleepScreenCache::save(renderer, sourcePath);
     }
-  }
-
-  if (hasGreyscale) {
-    if (greyscaleOnce && stripSink != nullptr) {
-      displaySleepGrayscaleBase(renderer);
-      stripSink->flushToDisplay(renderer);
-      renderer.displayGrayBuffer();
-      renderer.setRenderMode(GfxRenderer::BW);
-    } else {
-      renderSleepGrayscaleOverlay(renderer, [&]() {
-        bitmap.rewindToData();
-        renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
-      });
-    }
-  } else {
     displaySleepBuffer(renderer);
   }
 }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -67,7 +67,13 @@ bool tryDisplayCachedSleepScreen(const GfxRenderer& renderer, const std::string&
   auto& mutableRenderer = const_cast<GfxRenderer&>(renderer);
   if (wantsGreyscaleSleepCache()) {
     if (SleepScreenCache::loadGreyscale(mutableRenderer, sourcePath)) {
+      // BW base first, then grey planes. Loading greys before base on X3 sets
+      // lsbValid and forces displayGrayscaleBase to wipe controller RAM.
       displaySleepGrayscaleBase(renderer);
+      if (!SleepScreenCache::applyGreyscalePlanes(renderer, sourcePath)) {
+        LOG_ERR("SLP", "Cached greyscale planes failed to apply; falling back");
+        return false;
+      }
       renderer.displayGrayBuffer();
       mutableRenderer.setRenderMode(GfxRenderer::BW);
       return true;
@@ -625,6 +631,10 @@ bool renderBitmapStatsSleepScreen(GfxRenderer& renderer, const std::string& sour
     if (SleepScreenCache::loadGreyscale(renderer, sourcePath)) {
       drawCoverStatsPanel(renderer, statsPanel, book, footerOnly);
       displaySleepGrayscaleBase(renderer);
+      if (!SleepScreenCache::applyGreyscalePlanes(renderer, sourcePath)) {
+        LOG_ERR("SLP", "Cached greyscale planes failed to apply for stats sleep");
+        return false;
+      }
       renderer.displayGrayBuffer();
       renderer.setRenderMode(GfxRenderer::BW);
       return true;

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -29,8 +29,12 @@
 
 namespace {
 bool canUseSleepCache(const Bitmap& bitmap) {
-  return !(bitmap.hasGreyscale() &&
-           SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
+  return !bitmap.hasGreyscale() ||
+         SETTINGS.sleepScreenCoverFilter != CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+}
+
+bool wantsGreyscaleSleepCache() {
+  return SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 }
 
 bool usesCustomSleepImages() {
@@ -57,6 +61,25 @@ void displaySleepGrayscaleBase(const GfxRenderer& renderer) {
     return;
   }
   renderer.displayGrayscaleBase(mode);
+}
+
+bool tryDisplayCachedSleepScreen(const GfxRenderer& renderer, const std::string& sourcePath) {
+  auto& mutableRenderer = const_cast<GfxRenderer&>(renderer);
+  if (wantsGreyscaleSleepCache()) {
+    if (SleepScreenCache::loadGreyscale(mutableRenderer, sourcePath)) {
+      displaySleepGrayscaleBase(renderer);
+      renderer.displayGrayBuffer();
+      mutableRenderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    return false;
+  }
+
+  if (SleepScreenCache::load(mutableRenderer, sourcePath)) {
+    displaySleepBuffer(renderer);
+    return true;
+  }
+  return false;
 }
 
 template <typename RenderFn>
@@ -598,7 +621,15 @@ bool drawPngSleepBackground(const GfxRenderer& renderer, const std::string& sour
 
 bool renderBitmapStatsSleepScreen(GfxRenderer& renderer, const std::string& sourcePath, const Rect& statsPanel,
                                   const ReadingBookStats* book, const bool footerOnly) {
-  if (SleepScreenCache::load(renderer, sourcePath)) {
+  if (wantsGreyscaleSleepCache()) {
+    if (SleepScreenCache::loadGreyscale(renderer, sourcePath)) {
+      drawCoverStatsPanel(renderer, statsPanel, book, footerOnly);
+      displaySleepGrayscaleBase(renderer);
+      renderer.displayGrayBuffer();
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+  } else if (SleepScreenCache::load(renderer, sourcePath)) {
     drawCoverStatsPanel(renderer, statsPanel, book, footerOnly);
     displaySleepBuffer(renderer);
     return true;
@@ -713,17 +744,17 @@ void SleepActivity::renderCustomSleepScreen() const {
       }
     } else {
       GUI.drawPopup(renderer, tr(STR_ENTERING_SLEEP));
-      FsFile file;
-      if (SleepScreenCache::load(renderer, selected.path)) {
-        displaySleepBuffer(renderer);
+      if (tryDisplayCachedSleepScreen(renderer, selected.path)) {
         return;
       }
+      FsFile file;
       if (Storage.openFileForRead("SLP", selected.path, file)) {
         LOG_DBG("SLP", "Loading sleep image: %s", selected.path.c_str());
+        const uint32_t sourceFileSize = file.fileSize();
         delay(100);
         Bitmap bitmap(file, true);
         if (bitmap.parseHeaders() == BmpReaderError::Ok) {
-          renderBitmapSleepScreen(bitmap, selected.path);
+          renderBitmapSleepScreen(bitmap, selected.path, sourceFileSize);
           file.close();
           return;
         }
@@ -735,15 +766,15 @@ void SleepActivity::renderCustomSleepScreen() const {
   FsFile file;
   if (Storage.openFileForRead("SLP", "/sleep.bmp", file)) {
     GUI.drawPopup(renderer, tr(STR_ENTERING_SLEEP));
+    const uint32_t sourceFileSize = file.fileSize();
     Bitmap bitmap(file, true);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
-      if (SleepScreenCache::load(renderer, "/sleep.bmp")) {
-        displaySleepBuffer(renderer);
+      if (tryDisplayCachedSleepScreen(renderer, "/sleep.bmp")) {
         file.close();
         return;
       }
-      renderBitmapSleepScreen(bitmap, "/sleep.bmp");
+      renderBitmapSleepScreen(bitmap, "/sleep.bmp", sourceFileSize);
       file.close();
       return;
     }
@@ -782,7 +813,8 @@ void SleepActivity::renderDefaultSleepScreen() const {
   displaySleepBuffer(renderer);
 }
 
-void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const std::string& sourcePath) const {
+void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const std::string& sourcePath,
+                                            const uint32_t sourceFileSize) const {
   int x, y;
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
@@ -825,10 +857,26 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const std::str
   const bool hasGreyscale = bitmap.hasGreyscale() &&
                             SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 
-  SleepGreyStripBatch greyStrips;
+  SleepGreyStripBatch memoryStrips;
+  SleepGreyscaleStreamWriter streamWriter;
+  ISleepGreyStripSink* stripSink = nullptr;
+  if (hasGreyscale) {
+    if (!sourcePath.empty() &&
+        streamWriter.begin(sourcePath, sourceFileSize, display.getBufferSize(), renderer.getDisplayWidthBytes(),
+                           renderer.getDisplayHeight())) {
+      stripSink = &streamWriter;
+    } else if (sourcePath.empty()) {
+      stripSink = &memoryStrips;
+    }
+  }
+
   const bool greyscaleOnce =
-      hasGreyscale && renderer.drawGreyscaleBitmapForSleep(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, greyStrips);
+      hasGreyscale && stripSink != nullptr &&
+      renderer.drawGreyscaleBitmapForSleep(bitmap, x, y, pageWidth, pageHeight, cropX, cropY, *stripSink);
   if (!greyscaleOnce) {
+    if (streamWriter.isActive()) {
+      streamWriter.abort();
+    }
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
   }
 
@@ -836,14 +884,18 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const std::str
     renderer.invertScreen();
   }
 
-  if (!sourcePath.empty() && canUseSleepCache(bitmap)) {
-    SleepScreenCache::save(renderer, sourcePath);
+  if (!sourcePath.empty()) {
+    if (streamWriter.isActive() && greyscaleOnce) {
+      streamWriter.commitBw(renderer.getFrameBuffer(), display.getBufferSize());
+    } else if (canUseSleepCache(bitmap)) {
+      SleepScreenCache::save(renderer, sourcePath);
+    }
   }
 
   if (hasGreyscale) {
-    if (greyscaleOnce) {
+    if (greyscaleOnce && stripSink != nullptr) {
       displaySleepGrayscaleBase(renderer);
-      greyStrips.flush(renderer);
+      stripSink->flushToDisplay(renderer);
       renderer.displayGrayBuffer();
       renderer.setRenderMode(GfxRenderer::BW);
     } else {
@@ -938,16 +990,17 @@ void SleepActivity::renderCoverSleepScreen() const {
     return (this->*renderNoCoverSleepScreen)();
   }
 
-  FsFile file;
-  if (SleepScreenCache::load(renderer, coverBmpPath)) {
-    displaySleepBuffer(renderer);
+  if (tryDisplayCachedSleepScreen(renderer, coverBmpPath)) {
     return;
   }
+
+  FsFile file;
   if (Storage.openFileForRead("SLP", coverBmpPath, file)) {
+    const uint32_t sourceFileSize = file.fileSize();
     Bitmap bitmap(file);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
-      renderBitmapSleepScreen(bitmap, coverBmpPath);
+      renderBitmapSleepScreen(bitmap, coverBmpPath, sourceFileSize);
       file.close();
       return;
     }

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -19,7 +19,8 @@ class SleepActivity final : public Activity {
   void renderReadingDashboardSleepScreen() const;
   void renderCoverStatsSleepScreen(bool footerOnly = false) const;
   void renderCustomStatsSleepScreen(bool footerOnly = false) const;
-  void renderBitmapSleepScreen(const Bitmap& bitmap, const std::string& sourcePath = "") const;
+  void renderBitmapSleepScreen(const Bitmap& bitmap, const std::string& sourcePath = "",
+                               uint32_t sourceFileSize = 0) const;
   bool renderPngSleepScreen(const std::string& sourcePath) const;
   void renderBlankSleepScreen() const;
   bool resolveLastBookCoverPath(std::string& coverBmpPath) const;

--- a/src/util/SleepScreenCache.cpp
+++ b/src/util/SleepScreenCache.cpp
@@ -5,6 +5,11 @@
 #include <HalStorage.h>
 #include <Logging.h>
 
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <new>
+
 #include "CrossPointSettings.h"
 
 namespace {
@@ -33,13 +38,243 @@ uint32_t SleepScreenCache::hashKey(const std::string& sourcePath, const uint32_t
   hash *= 16777619u;
   hash ^= static_cast<uint8_t>(SETTINGS.sleepScreenCoverMode);
   hash *= 16777619u;
+  hash ^= CACHE_FORMAT_VERSION;
+  hash *= 16777619u;
   return hash;
 }
 
-std::string SleepScreenCache::getCachePath(const std::string& sourcePath, const uint32_t fileSize) {
+std::string SleepScreenCache::getCachePath(const std::string& sourcePath, const uint32_t fileSize, const char* suffix) {
   char filename[64];
-  snprintf(filename, sizeof(filename), "%s/%08x.raw", CACHE_DIR, hashKey(sourcePath, fileSize));
+  snprintf(filename, sizeof(filename), "%s/%08x%s", CACHE_DIR, hashKey(sourcePath, fileSize),
+           suffix != nullptr ? suffix : ".raw");
   return std::string(filename);
+}
+
+void SleepScreenCache::removeEntry(const std::string& sourcePath, const uint32_t sourceSize) {
+  Storage.remove(getCachePath(sourcePath, sourceSize, ".raw").c_str());
+  Storage.remove(getCachePath(sourcePath, sourceSize, ".lsb.raw").c_str());
+  Storage.remove(getCachePath(sourcePath, sourceSize, ".msb.raw").c_str());
+}
+
+bool SleepScreenCache::readPlaneFile(const char* path, uint8_t* buffer, const uint32_t bufferSize) {
+  FsFile file;
+  if (!Storage.openFileForRead("SLC", path, file)) {
+    return false;
+  }
+
+  if (file.fileSize() != bufferSize) {
+    LOG_ERR("SLC", "Invalid cache size for %s", path);
+    file.close();
+    Storage.remove(path);
+    return false;
+  }
+
+  const int bytesRead = file.read(buffer, bufferSize);
+  file.close();
+  if (bytesRead != static_cast<int>(bufferSize)) {
+    LOG_ERR("SLC", "Incomplete cache read for %s", path);
+    return false;
+  }
+
+  return true;
+}
+
+bool SleepScreenCache::writePlaneFile(const char* path, const uint8_t* buffer, const uint32_t bufferSize) {
+  FsFile file;
+  if (!Storage.openFileForWrite("SLC", path, file)) {
+    LOG_ERR("SLC", "Could not open cache file %s", path);
+    return false;
+  }
+
+  const size_t bytesWritten = file.write(buffer, bufferSize);
+  file.close();
+  if (bytesWritten != bufferSize) {
+    LOG_ERR("SLC", "Incomplete cache write for %s", path);
+    Storage.remove(path);
+    return false;
+  }
+
+  return true;
+}
+
+bool SleepGreyscaleStreamWriter::seekAndWrite(FsFile& file, const size_t offset, const uint8_t* data,
+                                              const size_t length) const {
+  if (data == nullptr || length == 0) {
+    return false;
+  }
+
+  const size_t endOffset = offset + length;
+  size_t fileSize = file.fileSize();
+  if (endOffset > fileSize) {
+    if (!file.seekSet(fileSize)) {
+      return false;
+    }
+    uint8_t zeros[256] = {};
+    size_t gap = endOffset - fileSize;
+    while (gap > 0) {
+      const size_t chunk = std::min(gap, sizeof(zeros));
+      if (file.write(zeros, chunk) != chunk) {
+        return false;
+      }
+      gap -= chunk;
+    }
+    fileSize = endOffset;
+  }
+
+  if (!file.seekSet(offset)) {
+    return false;
+  }
+  return file.write(data, length) == length;
+}
+
+void SleepGreyscaleStreamWriter::closeWriteFiles() {
+  if (lsbFile_) {
+    lsbFile_.close();
+  }
+  if (msbFile_) {
+    msbFile_.close();
+  }
+}
+
+bool SleepGreyscaleStreamWriter::begin(const std::string& sourcePath, const uint32_t sourceFileSize,
+                                       const uint32_t bufferSize, const uint16_t panelWidthBytes,
+                                       const uint16_t panelHeight) {
+  abort();
+
+  sourcePath_ = sourcePath;
+  sourceSize_ = sourceFileSize;
+  if (sourceSize_ == 0 || bufferSize == 0 || panelWidthBytes == 0 || panelHeight == 0) {
+    return false;
+  }
+
+  bufferSize_ = bufferSize;
+  panelWidthBytes_ = panelWidthBytes;
+  panelHeight_ = panelHeight;
+  bwPath_ = SleepScreenCache::getCachePath(sourcePath, sourceSize_, ".raw");
+  lsbPath_ = SleepScreenCache::getCachePath(sourcePath, sourceSize_, ".lsb.raw");
+  msbPath_ = SleepScreenCache::getCachePath(sourcePath, sourceSize_, ".msb.raw");
+
+  Storage.mkdir(SleepScreenCache::CACHE_DIR);
+  SleepScreenCache::removeEntry(sourcePath, sourceSize_);
+
+  if (!Storage.openFileForWrite("SLC", lsbPath_, lsbFile_) || !Storage.openFileForWrite("SLC", msbPath_, msbFile_)) {
+    LOG_ERR("SLC", "Could not open greyscale sleep cache for write");
+    closeWriteFiles();
+    SleepScreenCache::removeEntry(sourcePath, sourceSize_);
+    return false;
+  }
+
+  active_ = true;
+  wroteStrip_ = false;
+  return true;
+}
+
+bool SleepGreyscaleStreamWriter::appendStrip(const int yStart, const int numRows, const size_t stripBytes,
+                                             const uint8_t* lsb, const uint8_t* msb) {
+  if (!active_ || numRows <= 0 || stripBytes == 0 || lsb == nullptr || msb == nullptr) {
+    return false;
+  }
+
+  const size_t offset = static_cast<size_t>(yStart) * panelWidthBytes_;
+  if (offset + stripBytes > bufferSize_) {
+    LOG_ERR("SLC", "Greyscale sleep cache strip out of bounds");
+    return false;
+  }
+
+  if (!seekAndWrite(lsbFile_, offset, lsb, stripBytes)) {
+    LOG_ERR("SLC", "Failed to write greyscale LSB strip at y=%d", yStart);
+    return false;
+  }
+  if (!seekAndWrite(msbFile_, offset, msb, stripBytes)) {
+    LOG_ERR("SLC", "Failed to write greyscale MSB strip at y=%d", yStart);
+    return false;
+  }
+
+  wroteStrip_ = true;
+  return true;
+}
+
+bool SleepGreyscaleStreamWriter::commitBw(const uint8_t* bwBuffer, const uint32_t bufferSize) {
+  if (!active_ || bwBuffer == nullptr || bufferSize != bufferSize_ || !wroteStrip_) {
+    return false;
+  }
+
+  closeWriteFiles();
+
+  if (!SleepScreenCache::writePlaneFile(bwPath_.c_str(), bwBuffer, bufferSize)) {
+    SleepScreenCache::removeEntry(sourcePath_, sourceSize_);
+    active_ = false;
+    return false;
+  }
+
+  LOG_DBG("SLC", "Saved greyscale cache: %s", bwPath_.c_str());
+  return true;
+}
+
+void SleepGreyscaleStreamWriter::abort() {
+  closeWriteFiles();
+  if (!sourcePath_.empty() && sourceSize_ != 0) {
+    SleepScreenCache::removeEntry(sourcePath_, sourceSize_);
+  }
+  sourcePath_.clear();
+  sourceSize_ = 0;
+  bufferSize_ = 0;
+  panelWidthBytes_ = 0;
+  panelHeight_ = 0;
+  lsbPath_.clear();
+  msbPath_.clear();
+  bwPath_.clear();
+  active_ = false;
+  wroteStrip_ = false;
+}
+
+void SleepGreyscaleStreamWriter::flushToDisplay(const GfxRenderer& renderer) const {
+  if (!wroteStrip_ || panelWidthBytes_ == 0 || panelHeight_ == 0) {
+    return;
+  }
+
+  FsFile lsbFile;
+  FsFile msbFile;
+  if (!Storage.openFileForRead("SLC", lsbPath_, lsbFile) || !Storage.openFileForRead("SLC", msbPath_, msbFile)) {
+    LOG_ERR("SLC", "Could not open greyscale sleep cache for display flush");
+    return;
+  }
+
+  const size_t stripBytes = static_cast<size_t>(panelWidthBytes_) * STRIP_ROWS;
+  auto scratch = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
+  if (!scratch) {
+    LOG_ERR("SLC", "OOM: greyscale sleep cache flush strip (%zu bytes)", stripBytes);
+    lsbFile.close();
+    msbFile.close();
+    return;
+  }
+
+  const int lastStripIdx = (static_cast<int>(panelHeight_) - 1) / STRIP_ROWS;
+  for (int stripIdx = 0; stripIdx <= lastStripIdx; stripIdx++) {
+    const int yStart = stripIdx * STRIP_ROWS;
+    const int rows = std::min(STRIP_ROWS, static_cast<int>(panelHeight_) - yStart);
+    if (rows <= 0) {
+      continue;
+    }
+
+    const size_t activeStripBytes = static_cast<size_t>(panelWidthBytes_) * static_cast<size_t>(rows);
+    const size_t offset = static_cast<size_t>(yStart) * panelWidthBytes_;
+
+    if (!lsbFile.seekSet(offset) || lsbFile.read(scratch.get(), activeStripBytes) != static_cast<int>(activeStripBytes)) {
+      LOG_ERR("SLC", "Failed to read greyscale LSB strip at y=%d", yStart);
+      break;
+    }
+    renderer.writeGrayscalePlaneStrip(true, scratch.get(), yStart, rows);
+
+    if (!msbFile.seekSet(offset) || msbFile.read(scratch.get(), activeStripBytes) != static_cast<int>(activeStripBytes)) {
+      LOG_ERR("SLC", "Failed to read greyscale MSB strip at y=%d", yStart);
+      break;
+    }
+    renderer.writeGrayscalePlaneStrip(false, scratch.get(), yStart, rows);
+  }
+
+  lsbFile.close();
+  msbFile.close();
 }
 
 bool SleepScreenCache::load(GfxRenderer& renderer, const std::string& sourcePath) {
@@ -48,30 +283,50 @@ bool SleepScreenCache::load(GfxRenderer& renderer, const std::string& sourcePath
     return false;
   }
 
-  const auto path = getCachePath(sourcePath, sourceSize);
-  FsFile file;
-  if (!Storage.openFileForRead("SLC", path, file)) {
-    return false;
-  }
-
+  const auto path = getCachePath(sourcePath, sourceSize, ".raw");
   const uint32_t bufferSize = display.getBufferSize();
-  if (file.fileSize() != bufferSize) {
-    LOG_ERR("SLC", "Invalid cache size for %s", path.c_str());
-    file.close();
-    Storage.remove(path.c_str());
-    return false;
-  }
-
   uint8_t* frameBuffer = renderer.getFrameBuffer();
-  const int bytesRead = file.read(frameBuffer, bufferSize);
-  file.close();
-
-  if (bytesRead != static_cast<int>(bufferSize)) {
-    LOG_ERR("SLC", "Incomplete cache read for %s", path.c_str());
+  if (!readPlaneFile(path.c_str(), frameBuffer, bufferSize)) {
     return false;
   }
 
   LOG_DBG("SLC", "Loaded cache: %s", path.c_str());
+  return true;
+}
+
+bool SleepScreenCache::loadGreyscale(GfxRenderer& renderer, const std::string& sourcePath) {
+  const uint32_t sourceSize = getSourceFileSize(sourcePath);
+  if (sourceSize == 0) {
+    return false;
+  }
+
+  const uint32_t bufferSize = display.getBufferSize();
+  const auto bwPath = getCachePath(sourcePath, sourceSize, ".raw");
+  const auto lsbPath = getCachePath(sourcePath, sourceSize, ".lsb.raw");
+  const auto msbPath = getCachePath(sourcePath, sourceSize, ".msb.raw");
+
+  uint8_t* frameBuffer = renderer.getFrameBuffer();
+  if (!readPlaneFile(bwPath.c_str(), frameBuffer, bufferSize)) {
+    return false;
+  }
+
+  auto planeBuffer = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[bufferSize]);
+  if (!planeBuffer) {
+    LOG_ERR("SLC", "OOM: greyscale sleep cache plane (%u bytes)", bufferSize);
+    return false;
+  }
+
+  if (!readPlaneFile(lsbPath.c_str(), planeBuffer.get(), bufferSize)) {
+    return false;
+  }
+  display.copyGrayscaleLsbBuffers(planeBuffer.get());
+
+  if (!readPlaneFile(msbPath.c_str(), planeBuffer.get(), bufferSize)) {
+    return false;
+  }
+  display.copyGrayscaleMsbBuffers(planeBuffer.get());
+
+  LOG_DBG("SLC", "Loaded greyscale cache: %s", bwPath.c_str());
   return true;
 }
 
@@ -83,21 +338,9 @@ void SleepScreenCache::save(const GfxRenderer& renderer, const std::string& sour
     return;
   }
 
-  const auto path = getCachePath(sourcePath, sourceSize);
-  FsFile file;
-  if (!Storage.openFileForWrite("SLC", path, file)) {
-    LOG_ERR("SLC", "Could not open cache file %s", path.c_str());
-    return;
-  }
-
   const uint32_t bufferSize = display.getBufferSize();
-  const uint8_t* frameBuffer = renderer.getFrameBuffer();
-  const size_t bytesWritten = file.write(frameBuffer, bufferSize);
-  file.close();
-
-  if (bytesWritten != bufferSize) {
-    LOG_ERR("SLC", "Incomplete cache write for %s", path.c_str());
-    Storage.remove(path.c_str());
+  const auto path = getCachePath(sourcePath, sourceSize, ".raw");
+  if (!writePlaneFile(path.c_str(), renderer.getFrameBuffer(), bufferSize)) {
     return;
   }
 

--- a/src/util/SleepScreenCache.cpp
+++ b/src/util/SleepScreenCache.cpp
@@ -305,10 +305,43 @@ bool SleepScreenCache::loadGreyscale(GfxRenderer& renderer, const std::string& s
   const auto lsbPath = getCachePath(sourcePath, sourceSize, ".lsb.raw");
   const auto msbPath = getCachePath(sourcePath, sourceSize, ".msb.raw");
 
+  // Verify grey planes exist and match the panel buffer size before accepting the cache hit.
+  FsFile lsbFile;
+  FsFile msbFile;
+  if (!Storage.openFileForRead("SLC", lsbPath, lsbFile) || lsbFile.fileSize() != bufferSize) {
+    if (lsbFile) {
+      lsbFile.close();
+    }
+    return false;
+  }
+  lsbFile.close();
+  if (!Storage.openFileForRead("SLC", msbPath, msbFile) || msbFile.fileSize() != bufferSize) {
+    if (msbFile) {
+      msbFile.close();
+    }
+    return false;
+  }
+  msbFile.close();
+
   uint8_t* frameBuffer = renderer.getFrameBuffer();
   if (!readPlaneFile(bwPath.c_str(), frameBuffer, bufferSize)) {
     return false;
   }
+
+  LOG_DBG("SLC", "Loaded greyscale BW cache (planes deferred): %s", bwPath.c_str());
+  return true;
+}
+
+bool SleepScreenCache::applyGreyscalePlanes(const GfxRenderer& renderer, const std::string& sourcePath) {
+  (void)renderer;
+  const uint32_t sourceSize = getSourceFileSize(sourcePath);
+  if (sourceSize == 0) {
+    return false;
+  }
+
+  const uint32_t bufferSize = display.getBufferSize();
+  const auto lsbPath = getCachePath(sourcePath, sourceSize, ".lsb.raw");
+  const auto msbPath = getCachePath(sourcePath, sourceSize, ".msb.raw");
 
   auto planeBuffer = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[bufferSize]);
   if (!planeBuffer) {
@@ -326,7 +359,7 @@ bool SleepScreenCache::loadGreyscale(GfxRenderer& renderer, const std::string& s
   }
   display.copyGrayscaleMsbBuffers(planeBuffer.get());
 
-  LOG_DBG("SLC", "Loaded greyscale cache: %s", bwPath.c_str());
+  LOG_DBG("SLC", "Applied greyscale planes from cache");
   return true;
 }
 

--- a/src/util/SleepScreenCache.cpp
+++ b/src/util/SleepScreenCache.cpp
@@ -333,32 +333,70 @@ bool SleepScreenCache::loadGreyscale(GfxRenderer& renderer, const std::string& s
 }
 
 bool SleepScreenCache::applyGreyscalePlanes(const GfxRenderer& renderer, const std::string& sourcePath) {
-  (void)renderer;
   const uint32_t sourceSize = getSourceFileSize(sourcePath);
   if (sourceSize == 0) {
     return false;
   }
 
+  const uint16_t panelWidthBytes = renderer.getDisplayWidthBytes();
+  const uint16_t panelHeight = renderer.getDisplayHeight();
   const uint32_t bufferSize = display.getBufferSize();
   const auto lsbPath = getCachePath(sourcePath, sourceSize, ".lsb.raw");
   const auto msbPath = getCachePath(sourcePath, sourceSize, ".msb.raw");
 
-  auto planeBuffer = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[bufferSize]);
-  if (!planeBuffer) {
-    LOG_ERR("SLC", "OOM: greyscale sleep cache plane (%u bytes)", bufferSize);
+  FsFile lsbFile;
+  FsFile msbFile;
+  if (!Storage.openFileForRead("SLC", lsbPath, lsbFile) || !Storage.openFileForRead("SLC", msbPath, msbFile)) {
+    LOG_ERR("SLC", "Could not open greyscale planes for apply");
     return false;
   }
 
-  if (!readPlaneFile(lsbPath.c_str(), planeBuffer.get(), bufferSize)) {
+  constexpr int STRIP_ROWS = 80;
+  const size_t stripBytes = static_cast<size_t>(panelWidthBytes) * STRIP_ROWS;
+  auto scratch = std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[stripBytes]);
+  if (!scratch) {
+    LOG_ERR("SLC", "OOM: greyscale apply strip (%zu bytes)", stripBytes);
+    lsbFile.close();
+    msbFile.close();
     return false;
   }
-  display.copyGrayscaleLsbBuffers(planeBuffer.get());
 
-  if (!readPlaneFile(msbPath.c_str(), planeBuffer.get(), bufferSize)) {
-    return false;
+  const int lastStripIdx = (static_cast<int>(panelHeight) - 1) / STRIP_ROWS;
+  for (int stripIdx = 0; stripIdx <= lastStripIdx; stripIdx++) {
+    const int yStart = stripIdx * STRIP_ROWS;
+    const int rows = std::min(STRIP_ROWS, static_cast<int>(panelHeight) - yStart);
+    if (rows <= 0) {
+      continue;
+    }
+
+    const size_t activeStripBytes = static_cast<size_t>(panelWidthBytes) * static_cast<size_t>(rows);
+    const size_t offset = static_cast<size_t>(yStart) * panelWidthBytes;
+    if (offset + activeStripBytes > bufferSize) {
+      LOG_ERR("SLC", "Greyscale apply strip out of bounds at y=%d", yStart);
+      lsbFile.close();
+      msbFile.close();
+      return false;
+    }
+
+    if (!lsbFile.seekSet(offset) || lsbFile.read(scratch.get(), activeStripBytes) != static_cast<int>(activeStripBytes)) {
+      LOG_ERR("SLC", "Failed to read greyscale LSB strip at y=%d", yStart);
+      lsbFile.close();
+      msbFile.close();
+      return false;
+    }
+    renderer.writeGrayscalePlaneStrip(true, scratch.get(), yStart, rows);
+
+    if (!msbFile.seekSet(offset) || msbFile.read(scratch.get(), activeStripBytes) != static_cast<int>(activeStripBytes)) {
+      LOG_ERR("SLC", "Failed to read greyscale MSB strip at y=%d", yStart);
+      lsbFile.close();
+      msbFile.close();
+      return false;
+    }
+    renderer.writeGrayscalePlaneStrip(false, scratch.get(), yStart, rows);
   }
-  display.copyGrayscaleMsbBuffers(planeBuffer.get());
 
+  lsbFile.close();
+  msbFile.close();
   LOG_DBG("SLC", "Applied greyscale planes from cache");
   return true;
 }

--- a/src/util/SleepScreenCache.cpp
+++ b/src/util/SleepScreenCache.cpp
@@ -127,6 +127,17 @@ bool SleepGreyscaleStreamWriter::seekAndWrite(FsFile& file, const size_t offset,
   return file.write(data, length) == length;
 }
 
+bool SleepGreyscaleStreamWriter::seekAndRead(FsFile& file, const size_t offset, uint8_t* data,
+                                             const size_t length) const {
+  if (data == nullptr || length == 0) {
+    return false;
+  }
+  if (!file.seekSet(offset)) {
+    return false;
+  }
+  return file.read(data, length) == static_cast<int>(length);
+}
+
 void SleepGreyscaleStreamWriter::closeWriteFiles() {
   if (lsbFile_) {
     lsbFile_.close();
@@ -192,6 +203,25 @@ bool SleepGreyscaleStreamWriter::appendStrip(const int yStart, const int numRows
 
   wroteStrip_ = true;
   return true;
+}
+
+bool SleepGreyscaleStreamWriter::loadStrip(const int yStart, const int numRows, const size_t stripBytes, uint8_t* lsb,
+                                           uint8_t* msb) const {
+  if (!active_ || numRows <= 0 || stripBytes == 0 || lsb == nullptr || msb == nullptr) {
+    return false;
+  }
+
+  const size_t offset = static_cast<size_t>(yStart) * panelWidthBytes_;
+  if (offset + stripBytes > bufferSize_) {
+    return false;
+  }
+
+  // Files may not yet contain this strip (first visit) — treat as missing.
+  if (lsbFile_.fileSize() < offset + stripBytes || msbFile_.fileSize() < offset + stripBytes) {
+    return false;
+  }
+
+  return seekAndRead(lsbFile_, offset, lsb, stripBytes) && seekAndRead(msbFile_, offset, msb, stripBytes);
 }
 
 bool SleepGreyscaleStreamWriter::commitBw(const uint8_t* bwBuffer, const uint32_t bufferSize) {

--- a/src/util/SleepScreenCache.cpp
+++ b/src/util/SleepScreenCache.cpp
@@ -448,6 +448,32 @@ void SleepScreenCache::save(const GfxRenderer& renderer, const std::string& sour
   LOG_DBG("SLC", "Saved cache: %s", path.c_str());
 }
 
+bool SleepScreenCache::prepareGreyscaleSave(const std::string& sourcePath, const uint32_t sourceFileSize) {
+  if (sourcePath.empty() || sourceFileSize == 0) {
+    return false;
+  }
+  Storage.mkdir(CACHE_DIR);
+  removeEntry(sourcePath, sourceFileSize);
+  return true;
+}
+
+bool SleepScreenCache::saveFrameBufferPlane(const GfxRenderer& renderer, const std::string& sourcePath,
+                                            const uint32_t sourceFileSize, const char* suffix) {
+  if (sourcePath.empty() || sourceFileSize == 0 || suffix == nullptr) {
+    return false;
+  }
+
+  const uint32_t bufferSize = display.getBufferSize();
+  const auto path = getCachePath(sourcePath, sourceFileSize, suffix);
+  if (!writePlaneFile(path.c_str(), renderer.getFrameBuffer(), bufferSize)) {
+    removeEntry(sourcePath, sourceFileSize);
+    return false;
+  }
+
+  LOG_DBG("SLC", "Saved greyscale plane cache: %s", path.c_str());
+  return true;
+}
+
 int SleepScreenCache::invalidateAll() {
   auto dir = Storage.open(CACHE_DIR);
   if (!dir || !dir.isDirectory()) {

--- a/src/util/SleepScreenCache.h
+++ b/src/util/SleepScreenCache.h
@@ -17,6 +17,7 @@ class SleepGreyscaleStreamWriter : public ISleepGreyStripSink {
   bool isActive() const { return active_; }
 
   bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb) override;
+  bool loadStrip(int yStart, int numRows, size_t stripBytes, uint8_t* lsb, uint8_t* msb) const override;
   void flushToDisplay(const GfxRenderer& renderer) const override;
   bool empty() const override { return !wroteStrip_; }
 
@@ -27,10 +28,12 @@ class SleepGreyscaleStreamWriter : public ISleepGreyStripSink {
   static constexpr int STRIP_ROWS = 80;
 
   bool seekAndWrite(FsFile& file, size_t offset, const uint8_t* data, size_t length) const;
+  bool seekAndRead(FsFile& file, size_t offset, uint8_t* data, size_t length) const;
   void closeWriteFiles();
 
-  FsFile lsbFile_;
-  FsFile msbFile_;
+  // Mutable so const loadStrip can seek/read while files remain open O_RDWR.
+  mutable FsFile lsbFile_;
+  mutable FsFile msbFile_;
   std::string sourcePath_;
   uint32_t sourceSize_ = 0;
   uint32_t bufferSize_ = 0;
@@ -56,8 +59,8 @@ class SleepScreenCache {
 
  private:
   static constexpr const char* CACHE_DIR = "/.crosspoint/sleep_cache";
-  // Bump when cache file layout changes so stale entries are ignored.
-  static constexpr uint8_t CACHE_FORMAT_VERSION = 2;
+  // Bump when cache file layout / grey encode semantics change so stale entries are ignored.
+  static constexpr uint8_t CACHE_FORMAT_VERSION = 3;
 
   friend class SleepGreyscaleStreamWriter;
 

--- a/src/util/SleepScreenCache.h
+++ b/src/util/SleepScreenCache.h
@@ -55,6 +55,11 @@ class SleepScreenCache {
   // Streams cached LSB/MSB planes to the panel in strips (no full-plane heap alloc).
   static bool applyGreyscalePlanes(const GfxRenderer& renderer, const std::string& sourcePath);
   static void save(const GfxRenderer& renderer, const std::string& sourcePath);
+  // Overlay-path greyscale cache: call prepare, then saveFrameBufferPlane for .raw / .lsb.raw / .msb.raw
+  // while the matching plane still sits in the framebuffer.
+  static bool prepareGreyscaleSave(const std::string& sourcePath, uint32_t sourceFileSize);
+  static bool saveFrameBufferPlane(const GfxRenderer& renderer, const std::string& sourcePath, uint32_t sourceFileSize,
+                                   const char* suffix);
   static int invalidateAll();
 
  private:

--- a/src/util/SleepScreenCache.h
+++ b/src/util/SleepScreenCache.h
@@ -49,7 +49,7 @@ class SleepScreenCache {
   // Loads BW into the framebuffer and verifies grey plane files exist. Does not touch
   // controller grey RAM — call applyGreyscalePlanes after displaySleepGrayscaleBase.
   static bool loadGreyscale(GfxRenderer& renderer, const std::string& sourcePath);
-  // Copies cached LSB/MSB planes into controller RAM. Must run after the BW base refresh.
+  // Streams cached LSB/MSB planes to the panel in strips (no full-plane heap alloc).
   static bool applyGreyscalePlanes(const GfxRenderer& renderer, const std::string& sourcePath);
   static void save(const GfxRenderer& renderer, const std::string& sourcePath);
   static int invalidateAll();

--- a/src/util/SleepScreenCache.h
+++ b/src/util/SleepScreenCache.h
@@ -46,7 +46,11 @@ class SleepGreyscaleStreamWriter : public ISleepGreyStripSink {
 class SleepScreenCache {
  public:
   static bool load(GfxRenderer& renderer, const std::string& sourcePath);
+  // Loads BW into the framebuffer and verifies grey plane files exist. Does not touch
+  // controller grey RAM — call applyGreyscalePlanes after displaySleepGrayscaleBase.
   static bool loadGreyscale(GfxRenderer& renderer, const std::string& sourcePath);
+  // Copies cached LSB/MSB planes into controller RAM. Must run after the BW base refresh.
+  static bool applyGreyscalePlanes(const GfxRenderer& renderer, const std::string& sourcePath);
   static void save(const GfxRenderer& renderer, const std::string& sourcePath);
   static int invalidateAll();
 

--- a/src/util/SleepScreenCache.h
+++ b/src/util/SleepScreenCache.h
@@ -1,19 +1,65 @@
 #pragma once
 
+#include <HalStorage.h>
+
 #include <cstdint>
 #include <string>
 
+#include <SleepGreyStripSink.h>
+
 class GfxRenderer;
+
+// Streams grey LSB/MSB strips to the sleep cache on SD during decode so RAM stays bounded.
+class SleepGreyscaleStreamWriter : public ISleepGreyStripSink {
+ public:
+  bool begin(const std::string& sourcePath, uint32_t sourceFileSize, uint32_t bufferSize, uint16_t panelWidthBytes,
+             uint16_t panelHeight);
+  bool isActive() const { return active_; }
+
+  bool appendStrip(int yStart, int numRows, size_t stripBytes, const uint8_t* lsb, const uint8_t* msb) override;
+  void flushToDisplay(const GfxRenderer& renderer) const override;
+  bool empty() const override { return !wroteStrip_; }
+
+  bool commitBw(const uint8_t* bwBuffer, uint32_t bufferSize);
+  void abort();
+
+ private:
+  static constexpr int STRIP_ROWS = 80;
+
+  bool seekAndWrite(FsFile& file, size_t offset, const uint8_t* data, size_t length) const;
+  void closeWriteFiles();
+
+  FsFile lsbFile_;
+  FsFile msbFile_;
+  std::string sourcePath_;
+  uint32_t sourceSize_ = 0;
+  uint32_t bufferSize_ = 0;
+  uint16_t panelWidthBytes_ = 0;
+  uint16_t panelHeight_ = 0;
+  std::string lsbPath_;
+  std::string msbPath_;
+  std::string bwPath_;
+  bool active_ = false;
+  bool wroteStrip_ = false;
+};
 
 class SleepScreenCache {
  public:
   static bool load(GfxRenderer& renderer, const std::string& sourcePath);
+  static bool loadGreyscale(GfxRenderer& renderer, const std::string& sourcePath);
   static void save(const GfxRenderer& renderer, const std::string& sourcePath);
   static int invalidateAll();
 
  private:
   static constexpr const char* CACHE_DIR = "/.crosspoint/sleep_cache";
+  // Bump when cache file layout changes so stale entries are ignored.
+  static constexpr uint8_t CACHE_FORMAT_VERSION = 2;
+
+  friend class SleepGreyscaleStreamWriter;
 
   static uint32_t hashKey(const std::string& sourcePath, uint32_t fileSize);
-  static std::string getCachePath(const std::string& sourcePath, uint32_t fileSize);
+  static std::string getCachePath(const std::string& sourcePath, uint32_t fileSize, const char* suffix = ".raw");
+  static bool readPlaneFile(const char* path, uint8_t* buffer, uint32_t bufferSize);
+  static bool writePlaneFile(const char* path, const uint8_t* buffer, uint32_t bufferSize);
+  static void removeEntry(const std::string& sourcePath, uint32_t sourceSize);
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
I was having two problems on my X3 that this branch addresses:
  - going to sleep took a VERY long time. About 25 seconds before the sleep image showed up, and another 45 seconds after that before the power button would respond to wake it back up
  - when `Sleep Screen Cover Mode` was set to `crop`, the sleep screen was blank (bug #15 )
* **What changes are included?**
  - decode greyscale sleep BMP once instead of three passes (i.e. LSB/MSB)
  - downscale cover image if oversized
  - add sleep image cache, so we don't re-compute greyscale sleep image unnecessarily
  - fix crop bug (#15)
## Additional Context
The crop fix: Sleep screen cover crop mode skipped every row for standard bottom-up BMPs because crop bounds and screen Y were computed from file row index instead of image row-from-top. Now uses crop bottom-up BMPs using row-from-top mapping

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
