### PR TITLE
fix(storage): stamp SD files with RTC or last Sync Day time

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -353,6 +353,8 @@ void setup() {
     activityManager.goToFullScreenMessage("SD card error", EpdFontFamily::BOLD);
     return;
   }
+  // Stamp all SdFat creates/syncs with RTC time when available, else last Sync Day.
+  TimeUtils::registerSdFatDateTimeCallback();
 
   HalSystem::checkPanic();
   BootRecovery::initialize();

--- a/src/util/ScreenshotUtil.cpp
+++ b/src/util/ScreenshotUtil.cpp
@@ -80,6 +80,7 @@ void ScreenshotUtil::takeScreenshot(GfxRenderer& renderer) {
 
   bool saved = saveFramebufferAsBmp(filename, fb, renderer.getDisplayWidth(), renderer.getDisplayHeight());
   if (saved) {
+    // FAT create/modify times come from TimeUtils::registerSdFatDateTimeCallback().
     LOG_DBG("SCR", "Screenshot saved to %s", filename);
   } else {
     LOG_ERR("SCR", "Failed to save screenshot");

--- a/src/util/SdFatDateTime.cpp
+++ b/src/util/SdFatDateTime.cpp
@@ -1,0 +1,57 @@
+#include "TimeUtils.h"
+
+#include "CrossPointState.h"
+
+#include <Arduino.h>
+// Include SdFat's date helpers without HalStorage.h, which aliases FsFile to HalFile
+// and conflicts with SdFat's FsFile class in the same translation unit.
+#include <common/FsDateTime.h>
+
+#include <ctime>
+
+namespace {
+
+void sdFatDateTimeCallback(uint16_t* date, uint16_t* time, uint8_t* ms10) {
+  // Keep this path cheap: do not touch the RTC I2C bus here. Boot/loop already
+  // bridges RTC into the ESP system clock; Sync Day updates lastKnownValidTimestamp.
+  uint32_t epoch = TimeUtils::getCurrentValidTimestamp();
+  if (!TimeUtils::isClockValid(epoch)) {
+    epoch = APP_STATE.lastKnownValidTimestamp;
+  }
+
+  if (!TimeUtils::isClockValid(epoch)) {
+    // Match SdFat's placeholder when no wall clock is known yet.
+    *date = FS_DATE(compileYear(), 1, 1);
+    *time = FS_TIME(0, 0, 0);
+    *ms10 = 0;
+    return;
+  }
+
+  TimeUtils::configureTimezone();
+  time_t currentTime = static_cast<time_t>(epoch);
+  tm localTime = {};
+  if (localtime_r(&currentTime, &localTime) == nullptr) {
+    *date = FS_DATE(compileYear(), 1, 1);
+    *time = FS_TIME(0, 0, 0);
+    *ms10 = 0;
+    return;
+  }
+
+  const int year = localTime.tm_year + 1900;
+  if (year < 1980 || year > 2107) {
+    *date = FS_DATE(compileYear(), 1, 1);
+    *time = FS_TIME(0, 0, 0);
+    *ms10 = 0;
+    return;
+  }
+
+  *date = FS_DATE(static_cast<uint16_t>(year), static_cast<uint8_t>(localTime.tm_mon + 1),
+                  static_cast<uint8_t>(localTime.tm_mday));
+  *time = FS_TIME(static_cast<uint8_t>(localTime.tm_hour), static_cast<uint8_t>(localTime.tm_min),
+                  static_cast<uint8_t>(localTime.tm_sec));
+  *ms10 = (localTime.tm_sec & 1) ? 100 : 0;
+}
+
+}  // namespace
+
+void TimeUtils::registerSdFatDateTimeCallback() { FsDateTime::setCallback(sdFatDateTimeCallback); }

--- a/src/util/TimeUtils.cpp
+++ b/src/util/TimeUtils.cpp
@@ -148,6 +148,22 @@ uint32_t TimeUtils::getCurrentValidTimestamp() {
   return isClockValid(now) ? now : 0;
 }
 
+uint32_t TimeUtils::getBestEffortFileTimestamp() {
+  // Prefer a live system clock once RTC/NTP has been applied this boot.
+  const uint32_t authoritative = getAuthoritativeTimestamp();
+  if (isClockValid(authoritative)) {
+    return authoritative;
+  }
+
+  // Without a live clock, use the last Sync Day / last known good wall time.
+  if (isClockValid(APP_STATE.lastKnownValidTimestamp)) {
+    return APP_STATE.lastKnownValidTimestamp;
+  }
+
+  // Any currently valid system time (e.g. set without syncedThisBoot).
+  return getCurrentValidTimestamp();
+}
+
 bool TimeUtils::setCurrentDate(const int year, const unsigned month, const unsigned day, uint32_t* epochSeconds) {
   configureTimezone();
 

--- a/src/util/TimeUtils.h
+++ b/src/util/TimeUtils.h
@@ -12,6 +12,10 @@ bool isClockValid();
 bool isClockValid(uint32_t epochSeconds);
 uint32_t getAuthoritativeTimestamp();
 uint32_t getCurrentValidTimestamp();
+// Best wall-clock for SD FAT metadata: live RTC/NTP clock when available,
+// otherwise last Sync Day / last known good timestamp.
+uint32_t getBestEffortFileTimestamp();
+void registerSdFatDateTimeCallback();
 bool setCurrentDate(int year, unsigned month, unsigned day, uint32_t* epochSeconds = nullptr);
 bool getTimestampForLocalDate(int year, unsigned month, unsigned day, uint32_t* epochSeconds);
 uint32_t getLocalDayOrdinal(uint32_t epochSeconds);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

When CrossPoint writes to files, it doesn't use a timestamp, so all files always have the same modified time. You can't, for example, sort your sdcard's screenshot folder by timestamp.

* **What changes are included?**

Stamp sdcard operations with clock, either based on the X3's real clock or the fallback to the last synced date, since an approximately correct date timestamp is better than indistinguishable timestamps

## Additional Context

* I noticed the bogus timestamp issue initially on a screenshot I took, but this also applies to logs. Maybe crash dumps, too. All around a nice improvement, IMHO.
---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
