### PR TITLE
fix(reader): preserve exact EPUB reopen position

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -33,6 +33,7 @@
 #include "ProgressFile.h"
 #include "ProgressMapper.h"
 #include "QrDisplayActivity.h"
+#include "ReaderPosition.h"
 #include "ReaderQuickSettingsActivity.h"
 #include "ReaderUtils.h"
 #include "ReadingStatsStore.h"
@@ -371,14 +372,14 @@ bool EpubReaderActivity::buildTickHeapGate() {
 bool EpubReaderActivity::applyDeferredReposition() {
   if (!section || section->isBuilding() || cachedChapterTotalPageCount == 0) return false;
   bool changed = false;
-  if (currentSpineIndex == cachedSpineIndex && section->pageCount != cachedChapterTotalPageCount) {
-    const float progress = static_cast<float>(section->currentPage) / cachedChapterTotalPageCount;
-    int newPage = static_cast<int>(progress * section->pageCount);
-    newPage = std::max(0, std::min(newPage, static_cast<int>(section->pageCount) - 1));
+  if (currentSpineIndex == cachedSpineIndex) {
+    const int newPage = ReaderPosition::resolveRestoredPage(section->currentPage, cachedChapterTotalPageCount,
+                                                            section->pageCount, pendingPaginationReposition);
     changed = newPage != section->currentPage;
     section->currentPage = newPage;
   }
   cachedChapterTotalPageCount = 0;
+  pendingPaginationReposition = false;
   return changed;
 }
 
@@ -675,6 +676,7 @@ void EpubReaderActivity::toggleTemporaryStatusBar() {
   if (section) {
     cachedSpineIndex = currentSpineIndex;
     cachedChapterTotalPageCount = section->estimatedTotalPages();
+    pendingPaginationReposition = true;
     nextPageNumber = section->currentPage;
   }
   section.reset();
@@ -899,6 +901,7 @@ void EpubReaderActivity::applyReaderSettingsChanges(const ReaderSettingsSnapshot
     if (section) {
       cachedSpineIndex = currentSpineIndex;
       cachedChapterTotalPageCount = section->estimatedTotalPages();
+      pendingPaginationReposition = true;
       nextPageNumber = section->currentPage;
     }
     if (orientationChanged) {
@@ -1202,6 +1205,7 @@ void EpubReaderActivity::applyOrientation(const uint8_t orientation) {
     if (section) {
       cachedSpineIndex = currentSpineIndex;
       cachedChapterTotalPageCount = section->estimatedTotalPages();
+      pendingPaginationReposition = true;
       nextPageNumber = section->currentPage;
     }
 
@@ -1236,6 +1240,7 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
     if (section) {
       cachedSpineIndex = currentSpineIndex;
       cachedChapterTotalPageCount = section->estimatedTotalPages();
+      pendingPaginationReposition = true;
       nextPageNumber = section->currentPage;
     }
     section.reset();
@@ -1468,6 +1473,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     } else if (cacheComplete) {
       LOG_DBG("ERS", "Finalized cache found, skipping build");
       cachedChapterTotalPageCount = 0;
+      pendingPaginationReposition = false;
     } else if (cacheLoaded) {
       LOG_DBG("ERS", "Partial cache covers landing page; extension deferred");
     }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -26,6 +26,9 @@ class EpubReaderActivity final : public Activity {
   int pagesUntilFullRefresh = 0;
   int cachedSpineIndex = 0;
   int cachedChapterTotalPageCount = 0;
+  // Page numbers are stable across a progressive-cache rebuild. Remap by percentage only
+  // when a settings or viewport change actually caused the chapter to be repaginated.
+  bool pendingPaginationReposition = false;
   unsigned long lastPageTurnTime = 0UL;
   unsigned long pageTurnDuration = 0UL;
   // Signals that the next render should reposition within the newly loaded section

--- a/src/activities/reader/ReaderPosition.h
+++ b/src/activities/reader/ReaderPosition.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace ReaderPosition {
+
+inline int resolveRestoredPage(const int savedPage, const int savedPageCount, const int currentPageCount,
+                               const bool paginationChanged) {
+  if (currentPageCount <= 0) return 0;
+
+  int resolvedPage = savedPage;
+  if (paginationChanged && savedPageCount > 0 && savedPageCount != currentPageCount) {
+    const float progress = static_cast<float>(savedPage) / static_cast<float>(savedPageCount);
+    resolvedPage = static_cast<int>(progress * static_cast<float>(currentPageCount));
+  }
+
+  if (resolvedPage < 0) return 0;
+  if (resolvedPage >= currentPageCount) return currentPageCount - 1;
+  return resolvedPage;
+}
+
+}  // namespace ReaderPosition

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,3 +43,4 @@ enable_testing()
 include(GoogleTest)
 
 add_subdirectory(utf8_compose)
+add_subdirectory(reader_position)

--- a/test/reader_position/CMakeLists.txt
+++ b/test/reader_position/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(reader_position_test
+  ReaderPositionTest.cpp
+)
+
+target_link_libraries(reader_position_test PRIVATE
+  crosspoint_test_common
+  GTest::gtest_main
+)
+
+gtest_discover_tests(reader_position_test)

--- a/test/reader_position/ReaderPositionTest.cpp
+++ b/test/reader_position/ReaderPositionTest.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+
+#include "src/activities/reader/ReaderPosition.h"
+
+TEST(ReaderPositionTest, PreservesExactPageWhenProgressiveEstimateChanges) {
+  EXPECT_EQ(100, ReaderPosition::resolveRestoredPage(100, 200, 190, false));
+}
+
+TEST(ReaderPositionTest, RemapsRelativeProgressAfterRepagination) {
+  EXPECT_EQ(95, ReaderPosition::resolveRestoredPage(100, 200, 190, true));
+}
+
+TEST(ReaderPositionTest, ClampsExactPageWhenChapterShrinks) {
+  EXPECT_EQ(189, ReaderPosition::resolveRestoredPage(200, 220, 190, false));
+}


### PR DESCRIPTION
## Summary

- preserve the exact saved EPUB page when a progressive page-count estimate changes as indexing completes
- continue remapping by relative progress only after real repagination changes such as font, orientation, or viewport updates
- add native regression coverage for exact restore, repagination, and bounds clamping

Fixes #165.

## Validation

- ctest --output-on-failure: 9/9 passed
- python -m platformio run -e default: passed
- python -m platformio run -e gh_release: passed (1.5.0.5 candidate; 30.7% RAM, 92.7% flash)