### PR TITLE
fix(wifi): make Back dismiss the connection failure screen

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -56,6 +56,7 @@ void WifiSelectionActivity::onEnter() {
   savePromptSelection = 0;
   forgetPromptSelection = 0;
   autoConnecting = false;
+  autoConnectAttempted = false;
 
   // Cache the MAC address for display.
   // On ESP32, read the base MAC directly to avoid placeholder values when the
@@ -118,6 +119,31 @@ void WifiSelectionActivity::startWifiScan() {
 
   // Start async scan
   WiFi.scanNetworks(true);  // true = async scan
+}
+
+void WifiSelectionActivity::returnToNetworkList() {
+  // Back out of a prompt or a failure screen without rescanning. The cached
+  // scan results are still valid, so reusing them keeps the user's place
+  // instead of dropping them into another multi-second scan.
+  autoConnecting = false;
+  state = WifiSelectionState::NETWORK_LIST;
+
+  // Keep the network we were acting on under the cursor. A hidden network the
+  // user typed by hand is not in the scan list, so the cursor simply stays on
+  // the placeholder row it was launched from.
+  if (!selectedSSID.empty()) {
+    const auto selected = std::find_if(networks.begin(), networks.end(), [this](const WifiNetworkInfo& network) {
+      return !network.isHiddenPlaceholder && network.ssid == selectedSSID;
+    });
+    if (selected != networks.end()) {
+      selectedNetworkIndex = static_cast<size_t>(std::distance(networks.begin(), selected));
+    }
+  }
+  if (selectedNetworkIndex >= networks.size()) {
+    selectedNetworkIndex = 0;
+  }
+
+  requestUpdate();
 }
 
 void WifiSelectionActivity::processWifiScanResults() {
@@ -194,7 +220,8 @@ void WifiSelectionActivity::processWifiScanResults() {
   // connected SSID when it is present in scan results; otherwise fall back to
   // the strongest saved network because the list is already sorted with saved
   // networks first and RSSI descending inside each group.
-  if (allowAutoConnect && realNetworkCount > 0) {
+  if (allowAutoConnect && !autoConnectAttempted && realNetworkCount > 0) {
+    autoConnectAttempted = true;
     const std::string lastSsid = WIFI_STORE.getLastConnectedSsid();
     if (!lastSsid.empty()) {
       const auto remembered = std::find_if(networks.begin(), networks.end(), [&lastSsid](const WifiNetworkInfo& network) {
@@ -418,6 +445,9 @@ void WifiSelectionActivity::checkConnectionStatus() {
     if (status == WL_NO_SSID_AVAIL) {
       connectionError = tr(STR_ERROR_NETWORK_NOT_FOUND);
     }
+    // Stop the SDK from retrying in the background while the user is back in
+    // the list; the timeout path below does the same.
+    WiFi.disconnect();
     state = WifiSelectionState::CONNECTION_FAILED;
     requestUpdate();
     return;
@@ -522,10 +552,10 @@ void WifiSelectionActivity::loop() {
         }
       }
       // Go back to network list (whether Cancel or Forget network was selected)
-      startWifiScan();
+      returnToNetworkList();
     } else if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
       // Skip forgetting, go back to network list
-      startWifiScan();
+      returnToNetworkList();
     }
     return;
   }
@@ -540,19 +570,21 @@ void WifiSelectionActivity::loop() {
 
   // Handle connection failed state
   if (state == WifiSelectionState::CONNECTION_FAILED) {
-    if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
-        mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-      // If we were auto-connecting or using a saved credential, offer to forget
-      // the network
-      if (autoConnecting || usedSavedPassword) {
+    // Back always dismisses straight to the network list. Only Confirm opts in
+    // to the forget prompt, and only when a saved credential is what failed.
+    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      returnToNetworkList();
+      return;
+    }
+    if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+      if (usedSavedPassword) {
         autoConnecting = false;
         state = WifiSelectionState::FORGET_PROMPT;
         forgetPromptSelection = 0;  // Default to "Cancel"
+        requestUpdate();
       } else {
-        // Go back to network list on failure for non-saved credentials
-        state = WifiSelectionState::NETWORK_LIST;
+        returnToNetworkList();
       }
-      requestUpdate();
       return;
     }
   }
@@ -806,8 +838,10 @@ void WifiSelectionActivity::renderConnectionFailed() const {
   renderer.drawCenteredText(UI_12_FONT_ID, top - 20, tr(STR_CONNECTION_FAILED), true, EpdFontFamily::BOLD);
   renderer.drawCenteredText(UI_10_FONT_ID, top + 20, connectionError.c_str());
 
-  // Use centralized button hints
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_DONE), "", "");
+  // Confirm only leads to the forget prompt when a saved credential failed;
+  // otherwise it just dismisses like Back does.
+  const char* confirmLabel = usedSavedPassword ? tr(STR_FORGET_BUTTON) : tr(STR_DONE);
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), confirmLabel, "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 }
 

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -84,6 +84,11 @@ class WifiSelectionActivity final : public Activity {
   // Whether we are attempting to auto-connect
   bool autoConnecting = false;
 
+  // Whether auto-connect already ran for this activity entry. Auto-connect is a
+  // one-shot on entry; without this a rescan after a failed auto-connect would
+  // immediately retry the same network and trap the user in a loop.
+  bool autoConnectAttempted = false;
+
   // Save/forget prompt selection (0 = Yes, 1 = No)
   int savePromptSelection = 0;
   int forgetPromptSelection = 0;
@@ -101,6 +106,7 @@ class WifiSelectionActivity final : public Activity {
   void renderForgetPrompt() const;
 
   void startWifiScan();
+  void returnToNetworkList();
   void processWifiScanResults();
   void appendHiddenNetworkEntry();
   void selectNetwork(int index);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix Wi-Fi network selection so `<< Back` on the **Connection Failed** screen dismisses the screen instead of pushing the user deeper into the flow. For the callers that pass `autoConnect = true` this was an inescapable loop — the network list could not be reached at all.
* **What changes are included?**

Reported flow: on **Connection Failed**, pressing `<< Back` asks *"Forget Network?"*, and pressing `<< Back` again drops into scanning. Three separate bugs in `WifiSelectionActivity` stack up to produce it.

**1. Back and Confirm were one branch.** `CONNECTION_FAILED` OR'd both buttons together and that branch escalated to the forget prompt whenever a saved credential had been used — so `Back`, the universal "dismiss this", pushed *deeper* instead of out. Back now returns to the network list; only `Confirm` opens the forget prompt, and only when a saved credential is what actually failed.

**2. The Forget prompt rescanned instead of going back.** Cancel and Back both called `startWifiScan()`, despite the comment saying "go back to network list" — wiping the cached results, disconnecting Wi-Fi, and forcing another multi-second scan. Both now call a new `returnToNetworkList()`, which reuses the still-valid scan results and keeps the network you were acting on under the cursor.

**3. Together they looped forever.** For `autoConnect = true` callers (Sync Day, KOReader Sync, Clock Sync), that forced rescan re-ran auto-connect against the *same* network that had just failed → fail → Back → Forget → Back → scan → … Auto-connect is now one-shot per activity entry (`autoConnectAttempted`), so an explicit rescan gives you the list rather than silently redialing the failing network. A *failed* scan leaves the flag clear, so retrying after a bad scan still auto-connects.

Two smaller fixes in the same path:

* `WL_CONNECT_FAILED` now calls `WiFi.disconnect()`, matching what the timeout path already did — otherwise the SDK keeps retrying in the background while the user browses the list.
* The Confirm hint on the failure screen reads `Forget` when that is what it will do, instead of always claiming `Done`.

## Additional Context

* **No new user-facing strings.** The fix reuses `STR_FORGET_BUTTON` and `STR_DONE`, both already present in all 23 bundled languages, so there is no translation churn.
* **Hidden-network aware.** Rebased onto `1.5.0.5`, after `feat(wifi): support hidden network connections` changed the list invariants — `networks` now always carries a trailing placeholder row. `returnToNetworkList()` skips the placeholder when restoring the cursor, and the auto-connect gate keys off `realNetworkCount`. A hidden SSID typed by hand is not in the scan list, so the cursor simply stays on the placeholder row it was launched from.
* **Testing:** the fix was confirmed working on-device. It was then rebased from `1.3.0.36` onto current `master` (`1.5.0.5`) and adapted for the hidden-network placeholder as described above; the navigation logic is unchanged between the two.
* **Areas to focus on:** the `usedSavedPassword` condition now gates the forget prompt on its own — the previous `autoConnecting || usedSavedPassword` was redundant, since `connectUsingSavedCredential()` is the only thing that sets `autoConnecting` and it always sets `usedSavedPassword` alongside it.
* **Suggested repro:** connect to a saved network that will fail (wrong password, or out of range). On **Connection Failed**, `<< Back` should land on the network list with the failed network selected; `Forget` should open the prompt. From the prompt, both `<< Back` and `Cancel` should return to the list instantly, with no rescan.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
