### PR TITLE
fix(ui): wrap the confirmation body instead of truncating it

### DIFF
--- a/src/activities/util/ConfirmationActivity.cpp
+++ b/src/activities/util/ConfirmationActivity.cpp
@@ -18,14 +18,36 @@ void ConfirmationActivity::onEnter() {
   if (!heading.empty()) {
     safeHeading = renderer.truncatedText(fontId, heading.c_str(), maxWidth, EpdFontFamily::BOLD);
   }
+  // The body wraps rather than truncating: a prompt explaining what is about to
+  // happen is routinely longer than one line, and truncating it cut off the part
+  // that mattered. The heading stays single-line — it's a title, not prose.
+  //
+  // A newline in the body starts a new paragraph, so callers can separate the
+  // question being asked from the explanation of what it means instead of
+  // running them together as one block.
   if (!body.empty()) {
-    safeBody = renderer.truncatedText(fontId, body.c_str(), maxWidth, EpdFontFamily::REGULAR);
+    size_t start = 0;
+    while (start <= body.size() && static_cast<int>(bodyLines.size()) < maxBodyLines) {
+      const size_t newline = body.find('\n', start);
+      const std::string paragraph =
+          body.substr(start, newline == std::string::npos ? std::string::npos : newline - start);
+      if (paragraph.empty()) {
+        bodyLines.emplace_back();  // blank line between paragraphs
+      } else {
+        const int remaining = maxBodyLines - static_cast<int>(bodyLines.size());
+        const auto wrapped =
+            renderer.wrappedText(fontId, paragraph.c_str(), maxWidth, remaining, EpdFontFamily::REGULAR);
+        bodyLines.insert(bodyLines.end(), wrapped.begin(), wrapped.end());
+      }
+      if (newline == std::string::npos) break;
+      start = newline + 1;
+    }
   }
 
   int totalHeight = 0;
   if (!safeHeading.empty()) totalHeight += lineHeight;
-  if (!safeBody.empty()) totalHeight += lineHeight;
-  if (!safeHeading.empty() && !safeBody.empty()) totalHeight += spacing;
+  totalHeight += static_cast<int>(bodyLines.size()) * lineHeight;
+  if (!safeHeading.empty() && !bodyLines.empty()) totalHeight += spacing;
 
   startY = (renderer.getScreenHeight() - totalHeight) / 2;
 
@@ -44,8 +66,9 @@ void ConfirmationActivity::render(RenderLock&& lock) {
   }
 
   // Draw Body
-  if (!safeBody.empty()) {
-    renderer.drawCenteredText(fontId, currentY, safeBody.c_str(), true, EpdFontFamily::REGULAR);
+  for (const auto& line : bodyLines) {
+    renderer.drawCenteredText(fontId, currentY, line.c_str(), true, EpdFontFamily::REGULAR);
+    currentY += lineHeight;
   }
 
   // Draw UI Elements

--- a/src/activities/util/ConfirmationActivity.h
+++ b/src/activities/util/ConfirmationActivity.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "../../fontIds.h"
 #include "../Activity.h"
@@ -14,9 +15,10 @@ class ConfirmationActivity : public Activity {
   const int margin = 20;
   const int spacing = 30;
   const int fontId = UI_10_FONT_ID;
+  static constexpr int maxBodyLines = 6;
 
   std::string safeHeading;
-  std::string safeBody;
+  std::vector<std::string> bodyLines;
   int startY = 0;
   int lineHeight = 0;
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** A confirmation prompt whose body is longer than one line no longer gets cut off mid-sentence.
* **What changes are included?** `ConfirmationActivity` wraps the body to at most six lines instead of calling `truncatedText()` on it, and counts those lines when working out `startY`, so the block stays vertically centred. A `\n` in the body starts a new paragraph, so a caller can separate the question from the explanation. The heading is untouched — it's a title, not prose, and stays on one line.

## Why

The body was truncated to a single line, so anything explanatory lost its ending. It shows up most on prompts that describe consequences rather than just naming a thing — the part a user actually needs to read is the part that disappears.

The same fix is open against crosspoint-reader as [#2938](https://github.com/crosspoint-reader/crosspoint-reader/pull/2938), but it can't reach this fork: `ConfirmationActivity` has diverged between the two. Upstream draws the text with a centred `OptionPopup` over it, so there the body is capped at five lines to stay clear of the popup. This fork's version is a full-page prompt with no overlay, so the text is genuinely centred and six lines fit comfortably. Hence a separate PR written against this tree rather than a port of that patch.

## Testing

Built for the X4 (`-e default`). Flash 94.4%.

## Notes

Six is a cap, not a target — short bodies render exactly as they do today, on one centred line. Only bodies that would previously have been truncated look any different.
