### PR TITLE
fix: Skip KOReader auto sync when Wi-Fi unavailable

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -39,6 +39,12 @@ void WifiSelectionActivity::onEnter() {
     WIFI_STORE.loadFromFile();
   }
 
+  if (allowAutoConnect && autoConnectOnly && WIFI_STORE.getCredentials().empty()) {
+    LOG_DBG("WIFI", "Auto-connect only requested with no saved credentials");
+    onComplete(false);
+    return;
+  }
+
   // Reset state
   selectedNetworkIndex = 0;
   networks.clear();
@@ -157,6 +163,11 @@ void WifiSelectionActivity::processWifiScanResults() {
   if (scanResult == WIFI_SCAN_FAILED) {
     networks.clear();
     realNetworkCount = 0;
+    if (allowAutoConnect && autoConnectOnly) {
+      LOG_DBG("WIFI", "Auto-connect only requested but WiFi scan failed");
+      onComplete(false);
+      return;
+    }
     appendHiddenNetworkEntry();
     state = WifiSelectionState::NETWORK_LIST;
     selectedNetworkIndex = 0;
@@ -245,6 +256,12 @@ void WifiSelectionActivity::processWifiScanResults() {
         return;
       }
     }
+  }
+
+  if (allowAutoConnect && autoConnectOnly) {
+    LOG_DBG("WIFI", "Auto-connect only found no saved network in range");
+    onComplete(false);
+    return;
   }
 
   state = WifiSelectionState::NETWORK_LIST;

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -78,6 +78,10 @@ class WifiSelectionActivity final : public Activity {
   // Whether to attempt auto-connect on entry
   const bool allowAutoConnect;
 
+  // Whether to cancel instead of showing the network list when auto-connect
+  // cannot use a saved in-range network.
+  const bool autoConnectOnly;
+
   // Whether a successful connection should perform the one-time RTC sync hook.
   const bool syncRtcOnConnect;
 
@@ -122,9 +126,10 @@ class WifiSelectionActivity final : public Activity {
 
  public:
   explicit WifiSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, bool autoConnect = false,
-                                 bool syncRtcOnConnect = true)
+                                 bool syncRtcOnConnect = true, bool autoConnectOnly = false)
       : Activity("WifiSelection", renderer, mappedInput),
         allowAutoConnect(autoConnect),
+        autoConnectOnly(autoConnectOnly),
         syncRtcOnConnect(syncRtcOnConnect) {}
   void onEnter() override;
   void onExit() override;

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -77,6 +77,10 @@ bool shouldSyncNtpNow() {
   return ageSec >= static_cast<unsigned long>(NTP_RESYNC_MIN_INTERVAL_SEC);
 }
 
+bool isAutomaticSyncIntent(const KOReaderSyncIntentState intent) {
+  return intent == KOReaderSyncIntentState::AUTO_PULL || intent == KOReaderSyncIntentState::AUTO_PUSH;
+}
+
 void wifiOff() {
   TimeUtils::stopNtp();
   WiFi.disconnect(false);
@@ -508,9 +512,12 @@ void KOReaderSyncActivity::onEnter() {
     return;
   }
 
-  const bool chooseWifiManually = SETTINGS.syncDayWifiChoice == CrossPointSettings::SYNC_DAY_WIFI_MANUAL;
+  const bool automaticSync = isAutomaticSyncIntent(syncIntent);
+  const bool chooseWifiManually =
+      !automaticSync && SETTINGS.syncDayWifiChoice == CrossPointSettings::SYNC_DAY_WIFI_MANUAL;
   LOG_DBG("KOSync", "Launching WifiSelectionActivity...");
-  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput, !chooseWifiManually),
+  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput, !chooseWifiManually, true,
+                                                                 automaticSync),
                          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
 }
 


### PR DESCRIPTION
## Summary

- This addresses #189
- Adds an opt-in `autoConnectOnly` mode to `WifiSelectionActivity`.
- Uses that mode only for automatic KOReader Sync intents (`AUTO_PULL` / `AUTO_PUSH`), so auto-sync silently cancels when it cannot connect to a saved in-range network.
- Leaves manual KOReader Sync and other Wi-Fi flows unchanged, so users can still choose or configure Wi-Fi explicitly.

## Additional Context

The intended behavior is:
- If Wi-Fi is already connected, automatic KOSync continues normally.
- If a saved network is in range, automatic KOSync auto-connects and syncs normally.
- If no saved usable network is available, automatic KOSync skips that trigger and returns to reading without showing the Wi-Fi chooser.

Validation:
- `git diff --check` passes.
- Firmware build was not run locally because PlatformIO is not currently available in my CachyOS environment.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_